### PR TITLE
BugFix: get autmented mps #60

### DIFF
--- a/oqupy/mps_mpo.py
+++ b/oqupy/mps_mpo.py
@@ -23,7 +23,7 @@ from numpy import ndarray
 from scipy import linalg
 
 from oqupy.base_api import BaseAPIClass
-from oqupy.config import NpDtype, NpDtypeReal
+from oqupy.config import NpDtype
 SystemChain = Any # from oqupy.system import SystemChain
 
 class Gate:
@@ -417,9 +417,9 @@ class AugmentedMPS(BaseAPIClass):
         tmp_lambdas = []
         for bond_dim, l in zip(bond_dims, lambdas):
             if l is None:
-                tmp_lambda = np.ones(bond_dim, dtype=NpDtypeReal)
+                tmp_lambda = np.ones(bond_dim, dtype=NpDtype)
             else:
-                tmp_lambda = np.array(l, dtype=NpDtypeReal)
+                tmp_lambda = np.array(l, dtype=NpDtype)
                 shape = tmp_lambda.shape
                 rank = len(shape)
                 if rank == 2:

--- a/oqupy/pt_tebd.py
+++ b/oqupy/pt_tebd.py
@@ -332,12 +332,14 @@ class PtTebd(BaseAPIClass):
         self._chain_control = ChainControl(hilbert_space_dimensions=hs_dims)
 
     def get_augmented_mps(self) -> AugmentedMPS:
-        """Return the current AugmentedMPS. """
+        """Returns a copy of the current AugmentedMPS. """
+        if self._t_mps is None:
+            return self._initial_augmented_mps
         gammas = []
-        for i in range(len(self._t_mps)):
+        for i in range(self._t_mps.n):
             gammas.append(self._t_mps.get_gamma(i))
         lambdas = []
-        for i in range(len(self._t_mps) - 1):
+        for i in range(self._t_mps.n - 1):
             lambdas.append(self._t_mps.get_lambda(i))
 
         return AugmentedMPS(gammas, lambdas)

--- a/tests/coverage/pt_tebd_test.py
+++ b/tests/coverage/pt_tebd_test.py
@@ -1,0 +1,39 @@
+# Copyright 2022 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the time_evovling_mpo.pt_tebd module.
+"""
+
+import pytest
+
+import oqupy
+
+up_dm = oqupy.operators.spin_dm("z+")
+system_chain = oqupy.SystemChain(hilbert_space_dimensions=[2,2])
+initial_augmented_mps = oqupy.AugmentedMPS([up_dm, up_dm])
+pt_tebd_params = oqupy.PtTebdParameters(dt=0.2, order=2, epsrel=1.0e-4)
+
+def test_get_augmented_mps():
+    pt_tebd = oqupy.PtTebd(
+        initial_augmented_mps=initial_augmented_mps,
+        system_chain=system_chain,
+        process_tensors=[None, None],
+        parameters=pt_tebd_params)
+
+    augmented_mps = pt_tebd.get_augmented_mps()
+    assert augmented_mps.gammas[1].shape == (1,4,1,1)
+
+    pt_tebd.compute(end_step=1, progress_type='silent')
+    augmented_mps = pt_tebd.get_augmented_mps()
+    assert augmented_mps.gammas[1].shape == (1,4,1,1)


### PR DESCRIPTION
# Pull Request Check List

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [ ] API code contributions include input checks (defensive code).
* [ ] API code contributions include helpful error messages.
* [ ] The documentation has been updated:
  - [ ] docstring for all new functions/methods/classes/modules.
  - [ ] consistent style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [ ] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
