### PR TITLE
Mean field dev - restructured 

### DIFF
--- a/examples/tempo.py
+++ b/examples/tempo.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# coding: utf-8
+import sys
+sys.path.insert(0,'.')
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import oqupy
+import oqupy.operators as op
+
+# ----------------------------------------------------------------------------
+
+omega_cutoff = 5.0
+a = 0.1
+temperature = 0.1
+initial_state = oqupy.operators.spin_dm("z-")
+field = 1.0 + 1.0j
+
+# System parameters
+gn = 0.2    # Twice Rabi splitting
+gam_down = 0.01 # incoherent loss
+gam_up   = 0.01 # incoherent gain
+Sx=np.array([[0,0.5],[0.5,0]])
+wc=0.0
+kappa=0.1
+end_time=1#.1
+def H(t):
+    return 2.0 * gn * np.abs(field) * Sx
+    
+system = oqupy.TimeDependentSystem(H)
+correlations = oqupy.PowerLawSD(alpha=a, 
+                                zeta=1, 
+                                cutoff=omega_cutoff, 
+                                cutoff_type='gaussian', 
+                                temperature=temperature)
+bath = oqupy.Bath(oqupy.operators.sigma("z")/2.0, correlations)
+
+
+tempo_parameters = oqupy.TempoParameters(dt=0.1, dkmax=20, epsrel=10**(-7))
+
+tempo_sys = oqupy.Tempo(system=system,
+                        bath=bath,
+                        initial_state=initial_state,
+                        start_time=0.0,
+                        parameters=tempo_parameters)
+dynamics = tempo_sys.compute(end_time=end_time)
+with np.printoptions(precision=4):
+    for i,t in enumerate(dynamics._times):
+        print('t = {:.1f}\nState\n{}'.format(t,  dynamics._states[i]))
+

--- a/oqupy/dynamics.py
+++ b/oqupy/dynamics.py
@@ -43,6 +43,7 @@ class BaseDynamics(BaseAPIClass):
             self,
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
+        super().__init__(name, description)
         self._times = []
         self._states = []
         self._expectation_operators = []
@@ -241,6 +242,7 @@ class DynamicsWithField(BaseDynamics):
             fields: Optional[List[complex]] = None,
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
+        """Create a DynamicsWithField object"""
         super().__init__(name, description, description_dict)
         self._fields = []
         times, states = _parse_times_states(times, states)

--- a/oqupy/dynamics.py
+++ b/oqupy/dynamics.py
@@ -102,7 +102,6 @@ class BaseDynamics(BaseAPIClass):
         dyn = {"version": "1.0",
                "name": self.name,
                "description": self.description,
-               "description_dict": self.description_dict,
                "times": self.times,
                "states": self.states}
         assert_tempo_dynamics_dict(dyn)
@@ -190,7 +189,7 @@ class Dynamics(BaseDynamics):
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
         """Create a Dynamics object. """
-        super().__init__(name, description, description_dict)
+        super().__init__(name, description)
         times, states = _parse_times_states(times, states)
         for time, state in zip(times, states):
             self.add(time, state)
@@ -243,7 +242,7 @@ class DynamicsWithField(BaseDynamics):
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
         """Create a DynamicsWithField object"""
-        super().__init__(name, description, description_dict)
+        super().__init__(name, description)
         self._fields = []
         times, states = _parse_times_states(times, states)
         times, fields = _parse_times_fields(times, fields)

--- a/oqupy/dynamics.py
+++ b/oqupy/dynamics.py
@@ -295,7 +295,7 @@ def _parse_time(time) -> float:
         raise AssertionError("Argument `time` must be float.") from e
     return tmp_time
 
-def _parse_state(state, previous_shape) -> Tuple[ndarray, Tuple[int]]:  
+def _parse_state(state, previous_shape) -> Tuple[ndarray, Tuple[int]]:
     try:
         tmp_state = np.array(state, dtype=NpDtype)
     except Exception as e:

--- a/oqupy/dynamics.py
+++ b/oqupy/dynamics.py
@@ -62,13 +62,6 @@ class BaseDynamics(BaseAPIClass):
     def __len__(self) -> int:
         return len(self._times)
 
-    def _sort(self) -> None:
-        """Sort the time evolution (chronologically). """
-        tuples = zip(self._times, self._states)
-        __times, __states = zip(*sorted(tuples)) # ToDo: make more elegant
-        self._times = list(__times)
-        self._states = list(__states)
-
     @property
     def times(self) -> ndarray:
         """Times of the dynamics. """
@@ -111,22 +104,22 @@ class BaseDynamics(BaseAPIClass):
         if len(self) == 0:
             return None, None
         if operator is None:
-            __operator = np.identity(self._shape[0], dtype=NpDtype)
+            tmp_operator = np.identity(self._shape[0], dtype=NpDtype)
         else:
             try:
-                __operator = np.array(operator, dtype=NpDtype)
+                tmp_operator = np.array(operator, dtype=NpDtype)
             except Exception as e:
                 raise AssertionError("Argument `operator` must be ndarray.") \
                     from e
-            assert __operator.shape == self._shape, \
+            assert tmp_operator.shape == self._shape, \
                 "Argument `operator` must have the same shape as the " \
-                + "states. Has shape {}, ".format(__operator.shape) \
+                + "states. Has shape {}, ".format(tmp_operator.shape) \
                 + "but should be {}.".format(self._shape)
 
         expectations_list = []
 
         for state in self._states:
-            expectations_list.append(np.trace(__operator @ state))
+            expectations_list.append(np.trace(tmp_operator @ state))
 
         times = np.array(self._times)
         if real:
@@ -235,7 +228,7 @@ class DynamicsWithField(BaseDynamics):
         """
         if len(self) == 0:
             return None, None
-        return np.array(copy(self._times), dtype=NpDtypeReal), np.array(copy(self._fields),
+        return np.array(self._times, dtype=NpDtypeReal), np.array(self._fields,
                 dtype=NpDtype)
 
     def add(

--- a/oqupy/dynamics.py
+++ b/oqupy/dynamics.py
@@ -15,8 +15,9 @@
 Module on the discrete time evolution of a density matrix.
 """
 
-from typing import Dict, List, Optional, Text, Tuple
+from typing import List, Optional, Text, Tuple
 from copy import copy
+from bisect import bisect
 
 import numpy as np
 from numpy import ndarray
@@ -24,8 +25,149 @@ from numpy import ndarray
 from oqupy.base_api import BaseAPIClass
 from oqupy.config import NpDtype, NpDtypeReal
 
+class BaseDynamics(BaseAPIClass):
+    """
+    Base class for objects recording the dynamics of an open quantum
+    system. Consists at least of a list of times at which the dynamics
+    has been computed and a list of states describing the system density
+    matrix at those times.
 
-class Dynamics(BaseAPIClass):
+    Parameters
+    ----------
+    name: str
+        An optional name for the dynamics.
+    description: str
+        An optional description of the dynamics.
+    """
+    def __init__(
+            self,
+            name: Optional[Text] = None,
+            description: Optional[Text] = None) -> None:
+        self._times = []
+        self._states = []
+        self._expectation_operators = []
+        self._expectation_lists = []
+        self._shape = None
+
+    def __str__(self) -> Text:
+        ret = []
+        ret.append(super().__str__())
+        ret.append("  length        = {} timesteps \n".format(len(self)))
+        if len(self) > 0:
+            ret.append("  min time      = {} \n".format(
+                np.min(self._times)))
+            ret.append("  max time      = {} \n".format(
+                np.max(self._times)))
+        return "".join(ret)
+
+    def __len__(self) -> int:
+        return len(self._times)
+
+    def _sort(self) -> None:
+        """Sort the time evolution (chronologically). """
+        tuples = zip(self._times, self._states)
+        __times, __states = zip(*sorted(tuples)) # ToDo: make more elegant
+        self._times = list(__times)
+        self._states = list(__states)
+
+    @property
+    def times(self) -> ndarray:
+        """Times of the dynamics. """
+        return np.array(self._times, dtype=NpDtypeReal)
+
+    @property
+    def states(self) -> ndarray:
+        """States of the dynamics. """
+        return np.array(self._states, dtype=NpDtype)
+
+    @property
+    def shape(self) -> ndarray:
+        """Numpy shape of the states. """
+        return copy(self._shape)
+
+    def export(
+            self,
+            filename: Text,
+            overwrite: bool = False) -> None:
+        """
+        Save dynamics to a file (format TempoDynamicsFormat version 1.0).
+        Parameters
+        ----------
+        filename: str
+            Path and filename to file that should be created.
+        overwrite: bool (default = False)
+            If set `True` then file is overwritten in case it already exists.
+        """
+        dyn = {"version": "1.0",
+               "name": self.name,
+               "description": self.description,
+               "description_dict": self.description_dict,
+               "times": self.times,
+               "states": self.states}
+        assert_tempo_dynamics_dict(dyn)
+        save_object(dyn, filename, overwrite)
+
+    def expectations(
+            self,
+            operator: Optional[ndarray] = None,
+            real: Optional[bool] = False) -> Tuple[ndarray, ndarray]:
+        r"""
+        Return the time evolution of the expectation value of specific
+        operator. The expectation for :math:`t` is
+        .. math::
+            \langle \hat{O}(t) \rangle = \mathrm{Tr}\{ \hat{O} \rho(t) \}
+        with `operator` :math:`\hat{O}`.
+        Parameters
+        ----------
+        operator: ndarray (default = None)
+            The operator :math:`\hat{O}`. If `operator` is `None` then the
+            trace of :math:`\rho(t)` is returned.
+        real: bool (default = False)
+            If set True then only the real part of the expectation is returned.
+        Returns
+        -------
+        times: ndarray
+            The points in time :math:`t`.
+        expectations: ndarray
+            Expectation values :math:`\langle \hat{O}(t) \rangle`.
+        """
+        if len(self) == 0:
+            return None, None
+        if operator is None:
+            __operator = np.identity(self._shape[0], dtype=NpDtype)
+        else:
+            try:
+                __operator = np.array(operator, dtype=NpDtype)
+            except Exception as e:
+                raise AssertionError("Argument `operator` must be ndarray.") \
+                    from e
+            assert __operator.shape == self._shape, \
+                "Argument `operator` must have the same shape as the " \
+                + "states. Has shape {}, ".format(__operator.shape) \
+                + "but should be {}.".format(self._shape)
+
+        operator_index = next((i for i, op in \
+            enumerate(self._expectation_operators) if \
+            np.array_equal(op, __operator)), -1)
+        if operator_index == -1: # Operator not seen before
+            self._expectation_operators.append(__operator)
+            self._expectation_lists.append([])
+
+        expectations_list = self._expectation_lists[operator_index]
+
+        for state in self._states[len(expectations_list):]:
+            expectations_list.append(np.trace(__operator @ state))
+
+        self._expectation_lists[operator_index] = expectations_list
+
+        times = np.array(self._times)
+        if real:
+            expectations = np.real(np.array(expectations_list))
+        else:
+            expectations = np.array(expectations_list)
+        return times, expectations
+
+class Dynamics(BaseDynamics):
     """
     Represents a specific time evolution of a density matrix.
 
@@ -47,71 +189,17 @@ class Dynamics(BaseAPIClass):
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
         """Create a Dynamics object. """
-        # input check times and states
-        if times is None:
-            times = []
-        if states is None:
-            states = []
-        assert isinstance(times, list), \
-            "Argument `times` must be a list."
-        assert isinstance(states, list), \
-            "Argument `states` must be a list."
-        assert len(times) == len(states), \
-            "Lists `times` and `states` must have the same length."
-        self._times = []
-        self._states = []
-        self._expectation_operators = []
-        self._expectation_lists = []
-        self._shape = None
+        super().__init__(name, description, description_dict)
+        times, states = _parse_times_states(times, states)
         for time, state in zip(times, states):
             self.add(time, state)
-
-        super().__init__(name, description)
-
-    def __str__(self) -> Text:
-        ret = []
-        ret.append(super().__str__())
-        ret.append("  length        = {} timesteps \n".format(len(self)))
-        if len(self) > 0:
-            ret.append("  min time      = {} \n".format(
-                np.min(self._times)))
-            ret.append("  max time      = {} \n".format(
-                np.max(self._times)))
-        return "".join(ret)
-
-    def __len__(self) -> int:
-        return len(self._times)
-
-    def _sort(self) -> None:
-        """Sort the time evolution (chronologically). """
-        tuples = zip(self._times, self._states)
-        tmp_times, tmp_states = zip(*sorted(tuples)) # ToDo: make more elegant
-        self._times = list(tmp_times)
-        self._states = list(tmp_states)
-
-    @property
-    def times(self) -> ndarray:
-        """Times of the dynamics. """
-        return np.array(self._times, dtype=NpDtypeReal)
-
-    @property
-    def states(self) -> ndarray:
-        """States of the dynamics. """
-        return np.array(self._states, dtype=NpDtype)
-
-    @property
-    def shape(self) -> ndarray:
-        """Numpy shape of the states. """
-        return copy(self._shape)
 
     def add(
             self,
             time: float,
-            state: ndarray,
-            field: Optional[complex] = None) -> None:
+            state: ndarray) -> None:
         """
         Append a state at a specific time to the time evolution.
-
         Parameters
         ----------
         time: float
@@ -119,109 +207,19 @@ class Dynamics(BaseAPIClass):
         state: ndarray
             The state at the time `time`.
         """
-        try:
-            tmp_time = float(time)
-        except Exception as e:
-            raise AssertionError("Argument `time` must be float.") from e
-        try:
-            tmp_state = np.array(state, dtype=NpDtype)
-        except Exception as e:
-            raise AssertionError("Argument `state` must be ndarray.") from e
+        tmp_time = _parse_time(time)
+        tmp_state, tmp_shape = _parse_state(state, self._shape)
+        index = _find_list_index(self._times, tmp_time)
+        self._times.insert(index, tmp_time)
+        self._states.insert(index, tmp_state)
         if self._shape is None:
-            tmp_shape = tmp_state.shape
-            assert len(tmp_shape) == 2, \
-                "State must be a square matrix. " \
-                + "But the dimensions are {}.".format(tmp_shape)
-            assert tmp_shape[0] == tmp_shape[1], \
-                "State must be a square matrix. " \
-                + "But the dimensions are {}.".format(tmp_shape)
             self._shape = tmp_shape
-        else:
-            assert tmp_state.shape == self._shape, \
-                "Appended state doesn't have the same shape as previous " \
-                + "states ({}, but should be {})".format(tmp_state.shape,
-                                                         self._shape)
-
-        self._times.append(tmp_time)
-        self._states.append(tmp_state)
-
-        # ToDo: do this more elegantly and less resource draining.
-        if len(self) > 1 and (self._times[-1] < np.max(self._times[:-1])):
-            self._sort()
-
-    def expectations(
-            self,
-            operator: Optional[ndarray] = None,
-            real: Optional[bool] = False) -> Tuple[ndarray, ndarray]:
-        r"""
-        Return the time evolution of the expectation value of specific
-        operator. The expectation for :math:`t` is
-
-        .. math::
-
-            \langle \hat{O}(t) \rangle = \mathrm{Tr}\{ \hat{O} \rho(t) \}
-
-        with `operator` :math:`\hat{O}`.
-
-        Parameters
-        ----------
-        operator: ndarray (default = None)
-            The operator :math:`\hat{O}`. If `operator` is `None` then the
-            trace of :math:`\rho(t)` is returned.
-        real: bool (default = False)
-            If set True then only the real part of the expectation is returned.
-
-        Returns
-        -------
-        times: ndarray
-            The points in time :math:`t`.
-        expectations: ndarray
-            Expectation values :math:`\langle \hat{O}(t) \rangle`.
-        """
-        if len(self) == 0:
-            return None, None
-        if operator is None:
-            tmp_operator = np.identity(self._shape[0], dtype=NpDtype)
-        else:
-            try:
-                tmp_operator = np.array(operator, dtype=NpDtype)
-            except Exception as e:
-                raise AssertionError("Argument `operator` must be ndarray.") \
-                    from e
-            assert tmp_operator.shape == self._shape, \
-                "Argument `operator` must have the same shape as the " \
-                + "states. Has shape {}, ".format(tmp_operator.shape) \
-                + "but should be {}.".format(self._shape)
-
-        operator_index = next((i for i, op in \
-            enumerate(self._expectation_operators) if \
-            np.array_equal(op, tmp_operator)), -1)
-        if operator_index == -1: # Operator not seen before
-            self._expectation_operators.append(tmp_operator)
-            self._expectation_lists.append([])
-
-        expectations_list = self._expectation_lists[operator_index]
-
-        for state in self._states[len(expectations_list):]:
-            expectations_list.append(np.trace(tmp_operator @ state))
-
-        self._expectation_lists[operator_index] = expectations_list
-
-        times = np.array(self._times)
-        if real:
-            expectations = np.real(np.array(expectations_list))
-        else:
-            expectations = np.array(expectations_list)
-        return times, expectations
 
 
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# -- partly copied code -------------------------------------------------------
-
-class DynamicsWithField(Dynamics, BaseAPIClass):
+class DynamicsWithField(BaseDynamics):
     """
-    Represents a specific time evolution of a density matrix together with a
-    coherent field.
+    Represents a specific time evolution of a density matrix together
+    with a coherent field.
 
     Parameters
     ----------
@@ -234,7 +232,7 @@ class DynamicsWithField(Dynamics, BaseAPIClass):
     name: str
         An optional name for the dynamics.
     description: str
-        An optional description of the dynamics (unused).
+        An optional description of the dynamics.
     """
     def __init__(
             self,
@@ -243,38 +241,19 @@ class DynamicsWithField(Dynamics, BaseAPIClass):
             fields: Optional[List[complex]] = None,
             name: Optional[Text] = None,
             description: Optional[Text] = None) -> None:
-        if times is None:
-            times = []
-        if states is None:
-            states = []
-        if fields is None:
-            fields = []
-        assert isinstance(times, list), \
-            "Argument `times` must be a list."
-        assert isinstance(states, list), \
-            "Argument `states` must be a list."
-        assert isinstance(fields, list), \
-            "Argument `fields` must be a list."
-        assert len(times) == len(states), \
-            "Lists `times` and `states` must have the same length."
-        assert len(times) == len(fields), \
-            "Lists `times` and `fields` must have the same length."
-        self._times = []
-        self._states = []
+        super().__init__(name, description, description_dict)
         self._fields = []
-        self._expectation_operators = []
-        self._expectation_lists = []
-        self._shape = None
+        times, states = _parse_times_states(times, states)
+        times, fields = _parse_times_fields(times, fields)
         for time, state, field in zip(times, states, fields):
             self.add(time, state, field)
-        BaseAPIClass.__init__(self, name, description)
 
     @property
     def fields(self) -> ndarray:
         """Fields of the dynamics. """
         return np.array(self._fields, dtype=NpDtype)
 
-    def field_expectations(self):
+    def field_expectations(self) -> Tuple[ndarray, ndarray]:
         r"""
         Return the time evolution of the coherent field.
 
@@ -294,7 +273,7 @@ class DynamicsWithField(Dynamics, BaseAPIClass):
             self,
             time: float,
             state: ndarray,
-            field: Optional[complex] = None) -> None:
+            field: complex) -> None:
         """
         Append a state and field at a specific time to the time evolution.
 
@@ -307,9 +286,83 @@ class DynamicsWithField(Dynamics, BaseAPIClass):
         field: complex
             The field at the time `time`.
         """
-        try:
-            __field = complex(field)
-        except Exception as e:
-            raise AssertionError("Argument `field` must be complex.") from e
-        super().add(time, state)
-        self._fields.append(__field)
+        tmp_time = _parse_time(time)
+        tmp_state, tmp_shape = _parse_state(state, self._shape)
+        tmp_field = _parse_field(field)
+        index = _find_list_index(self._times, tmp_time)
+        self._times.insert(index, tmp_time)
+        self._states.insert(index, tmp_state)
+        self._fields.insert(index, tmp_field)
+        if self._shape is None:
+            self._shape = tmp_shape
+
+def _parse_times_states(times, states) -> Tuple[List[float],
+        List[ndarray]] :
+    """Check times and states are None or lists of the same length"""
+    if times is None:
+        times = []
+    if states is None:
+        states = []
+    assert isinstance(times, list), \
+        "Argument `times` must be a list."
+    assert isinstance(states, list), \
+        "Argument `states` must be a list."
+    assert len(times) == len(states), \
+        "Lists `times` and `states` must have the same length."
+    return times, states
+
+def _parse_times_fields(times, fields) -> Tuple[List[float],
+        List[complex]]:
+    """Check times and fields are None or lists of the same length"""
+    if times is None:
+        times = []
+    if fields is None:
+        fields = []
+    assert isinstance(times, list), \
+        "Argument `times` must be a list."
+    assert isinstance(fields, list), \
+        "Argument `fields` must be a list."
+    assert len(times) == len(fields), \
+        "Lists `times` and `fields` must have the same length."
+    return times, fields
+
+def _parse_time(time) -> float:
+    try:
+        tmp_time = float(time)
+    except Exception as e:
+        raise AssertionError("Argument `time` must be float.") from e
+    return tmp_time
+
+def _parse_state(state, previous_shape) -> Tuple[ndarray, Tuple[int]]:  
+    try:
+        tmp_state = np.array(state, dtype=NpDtype)
+    except Exception as e:
+        raise AssertionError("Argument `state` must be ndarray.") from e
+    tmp_shape = tmp_state.shape
+    if previous_shape is not None:
+        assert tmp_state.shape == previous_shape, \
+            "Appended state doesn't have the same shape as previous " \
+            + "states ({}, but should be {})".format(tmp_state.shape,
+                                                         previous_shape)
+    assert len(tmp_shape) == 2, \
+            "State must be a square matrix. " \
+            + "But the dimensions are {}.".format(tmp_shape)
+    assert tmp_shape[0] == tmp_shape[1], \
+            "State must be a square matrix. " \
+            + "But the dimensions are {}.".format(tmp_shape)
+    return tmp_state, tmp_shape
+
+def _parse_field(field) -> complex:
+    try:
+        tmp_field = complex(field)
+    except Exception as e:
+        raise AssertionError("Argument `field` must be complex.") from e
+    return tmp_field
+
+def _find_list_index(sorted_list, entry_value) -> int:
+    """
+    Return `index` such that a `sorted_list` stays sorted when extended with
+    `entry_value` like so:
+       `sorted_list.insert(index, entry_value)`
+    """
+    return bisect(sorted_list, entry_value)

--- a/oqupy/tempo/backends/tempo_backend.py
+++ b/oqupy/tempo/backends/tempo_backend.py
@@ -348,7 +348,8 @@ class TempoWithFieldBackend(BaseTempoBackend):
             initial_field: ndarray,
             influence: Callable[[int], ndarray],
             unitary_transform: ndarray,
-            propagators: Callable[[int, ndarray, complex], Tuple[ndarray, ndarray]],
+            propagators: Callable[[int, ndarray, complex],
+                Tuple[ndarray, ndarray]],
             compute_field: Callable[[float, ndarray, complex], complex],
             sum_north: ndarray,
             sum_west: ndarray,
@@ -396,4 +397,3 @@ class TempoWithFieldBackend(BaseTempoBackend):
         self._step = next_step
 
         return self._step, copy(self._state), self._field
-

--- a/tests/coverage/dynamics_test.py
+++ b/tests/coverage/dynamics_test.py
@@ -18,7 +18,7 @@ Tests for the time_evovling_mpo.dynamics module.
 import pytest
 import numpy as np
 
-from oqupy.dynamics import Dynamics, DynamicsWithField
+from oqupy.dynamics import BaseDynamics, Dynamics, DynamicsWithField
 
 
 times = [0.0, 0.1]
@@ -28,6 +28,16 @@ other_time = 0.05
 other_state = np.array([[0.99, -0.01j], [0.01j, 0.01]])
 other_field = 1e2j
 
+def test_base_dynamics():
+    dyn_A = BaseDynamics()
+    str(dyn_A)
+    len(dyn_A)
+    assert type(dyn_A.times) == np.ndarray
+    assert type(dyn_A.states) == np.ndarray
+    assert dyn_A.shape is None
+    t, expec = dyn_A.expectations()
+    assert t is None
+    assert expec is None
 
 def test_dynamics():
     dyn_A = Dynamics()
@@ -88,7 +98,10 @@ def test_dynamics_with_field():
     assert len(dyn_B) == len(times)
     np.testing.assert_almost_equal(fields, dyn_B.fields)
     dyn_B.add(other_time, other_state, other_field)
+    combined_fields = [fields[0], other_field, fields[1]]
     # bad input
+    with pytest.raises(AssertionError):
+        DynamicsWithField(times, states)
     with pytest.raises(AssertionError):
         DynamicsWithField(times, states, 0.1)
     with pytest.raises(AssertionError):
@@ -102,5 +115,6 @@ def test_dynamics_with_field():
     t, alpha = dyn_B.field_expectations()
     np.testing.assert_almost_equal(t, dyn_B.times)
     np.testing.assert_almost_equal(alpha, dyn_B.fields)
+    np.testing.assert_almost_equal(alpha, combined_fields)
     with pytest.raises(TypeError):
         dyn_B.field_expectations("bla")

--- a/tests/coverage/tempo/tempo_test.py
+++ b/tests/coverage/tempo/tempo_test.py
@@ -142,6 +142,22 @@ def test_guess_tempo_parameters():
                                              end_time=15.0,
                                              tolerance=1.0e-12)
 
+def test_tempo_time_dependent():
+    # Tempo class must be able to handle TimeDependentSystem as well
+    system = tempo.TimeDependentSystem(lambda t: t * 0.5 * tempo.operators.sigma("z"))
+    correlations = tempo.PowerLawSD(alpha=0.2,
+                                    zeta=2,
+                                    cutoff=1.0,
+                                    cutoff_type='exponential')
+    bath = tempo.Bath(0.1 * tempo.operators.sigma("x"), correlations)
+    tempo_parameters = tempo.TempoParameters(dt=0.1, dkmax=10, epsrel=10**(-2))
+    tempo_A= tempo.Tempo(system=system,
+                        bath=bath,
+                        parameters=tempo_parameters,
+                        initial_state=tempo.operators.spin_dm("down"),
+                        start_time=0.5)
+    dyn_A = tempo_A.compute(0.6)
+
 def test_tempo_compute():
     start_time = -0.3
     end_time = 0.84


### PR DESCRIPTION
Mean-field development with revised BaseClass structure in `dynamics.py`, `system.py`, `tempo.py`. `contractions.py` (PT-TEMPO) remains unchanged.

- [x] The contribution has been discussed and agreed on in #55, #56, #57 
- [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/) (Type checking withstanding).
- [x] The automated test are all positive (ignoring `contractions.py`)
- [x] Added test for changed/added code 
- [x] API code contributions include input checks (left Type checking in SystemWithField)).
- [x] API code contributions include helpful error messages.
- [x] The documentation has been updated (note doc for `tempo_backend.py` still lacking)
