### PR TITLE
Final changes to mean-field dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,8 @@ and you can pick a specific test to run with:
 ```bash
 $ tox -e py36 say_hi_test.py
 ```
+Here `say_hi_test.py` is the path of the test file *relative to the tests
+directory.*
 
 #### 7.3 test pylint only
 This checks the code [code style](https://www.python.org/dev/peps/pep-0008/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ systems [3-5]. This includes methods to compute ...
 - the dynamics of a strongly coupled bosonic environment [6].
 - the dynamics of a quantum system coupled to multiple non-Markovian environments [7].
 - the dynamics of a chain of non-Markovian open quantum systems [8].
-- the dynamics of an open many-body system with many-to-one light-matter
+- the dynamics of an open many-body system with one-to-all light-matter
   coupling [9].
 
 Up to versions 0.1.x this package was called *TimeEvolvingMPO*.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,8 @@ systems [3-5]. This includes methods to compute ...
 - the dynamics of a strongly coupled bosonic environment [6].
 - the dynamics of a quantum system coupled to multiple non-Markovian environments [7].
 - the dynamics of a chain of non-Markovian open quantum systems [8].
+- the dynamics of an open many-body system with many-to-one light-matter
+  coupling [9].
 
 Up to versions 0.1.x this package was called *TimeEvolvingMPO*.
 
@@ -50,6 +52,8 @@ Up to versions 0.1.x this package was called *TimeEvolvingMPO*.
   `arXiv:2109.08442 <http://arxiv.org/abs/2109.08442>`_ (2021).
 - **[8]** Fux et al.,
   `arXiv:2201.05529 <http://arxiv.org/abs/2201.05529>`_ (2022).
+- **[9]** Fowler-Wright at al.,
+  `arXiv:2112.09003 <http://arxiv.org/abs/2112.09003>`_ (2021)
 
 .. |binder-tutorial| image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/tempoCollaboration/TimeEvolvingMPO/master?filepath=tutorials%2Ftutorial_01_quickstart.ipynb

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -33,6 +33,11 @@ class :class:`oqupy.system.BaseSystem`
     Encodes a time dependent system Hamiltonian and possibly some additional
     time dependent Markovian decay.
 
+  class :class:`oqupy.system.TimeDependentSystemWithField`
+    Encodes a time dependent system Hamiltonian (and possibly some additional
+    time dependent Markovian decay) that couples to a classical field which
+    in turn evolves according to a prescribed Heisenberg equation of motion.
+
 class :class:`oqupy.system.SystemChain`
   Encodes a 1D chain of systems and possibly some additional Markovian decay.
 
@@ -78,12 +83,23 @@ TEMPO
 class :class:`oqupy.tempo.TempoParameters`
   Stores a set of parameters for a TEMPO computation.
 
-class :class:`oqupy.tempo.Tempo`
-  Class to facilitate a TEMPO computation.
+class :class:`oqupy.system.BaseTempo`
+  Abstract class for all TEMPO computations.
 
-  method :meth:`oqupy.tempo.Tempo.compute`
-    Method that carries out a TEMPO computation and creates an
-    :class:`oqupy.dynamics.Dynamics` object.
+  class :class:`oqupy.tempo.Tempo`
+    Class to facilitate a TEMPO computation.
+    
+    method :meth:`oqupy.tempo.Tempo.compute`
+      Method that carries out a TEMPO computation and creates a
+      :class:`oqupy.dynamics.Dynamics` object.
+
+  class :class:`oqupy.tempo.TempoWithField`
+    Class to facilitate a TEMPO computation with concurrent evolution of
+    a classical field.
+    
+    method :meth:`oqupy.tempo.TempoWithField.compute`
+      Method that carries out a TEMPO computation while evolving a classical
+      field, and creates a :class:`oqupy.dynamics.DynamicsWithField` object.
 
 function :func:`oqupy.tempo.guess_tempo_parameters`
   Function that chooses an appropriate set of parameters for a particular
@@ -107,7 +123,13 @@ Process Tensor Applications
 
 function :func:`oqupy.contractions.compute_dynamics`
   Compute a :class:`oqupy.dynamics.Dynamics` object for given
-  :class:`oqupy.system.BaseSystem` and
+  :class:`oqupy.system.System` :class:`oqupy.system.TimeDependentSystem` and
+  :class:`oqupy.control.Control` and
+  :class:`oqupy.process_tensor.BaseProcessTensor` objects.
+
+function :func:`oqupy.contractions.compute_dynamics_with_field`
+  Compute a :class:`oqupy.dynamics.DynamicsWithField` object for given
+  :class:`oqupy.system.TimeDependentSystemWithField` and
   :class:`oqupy.control.Control` and
   :class:`oqupy.process_tensor.BaseProcessTensor` objects.
 
@@ -151,14 +173,18 @@ class :class:`oqupy.dynamics.Dynamics`
   Object that encodes the discretized evolution of the reduced density matrix
   of a system.
 
+class :class:`oqupy.dynamics.DynamicsWithField`
+  Object that encodes the discretized evolution of the reduced density matrix
+  of a system together with that of a classical field.
+
 class :class:`oqupy.process_tensor.BaseProcessTensor`
   Object that encodes a so called process tensor (which captures all possible
   Markovian and non-Markovian interactions between some system and an
   environment).
 
 
-Utillities
-----------
+Utilities
+---------
 
 module :mod:`oqupy.operators`
   Supplies several commonly used operators, such as the Pauli matrices and spin

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -123,7 +123,8 @@ Process Tensor Applications
 
 function :func:`oqupy.contractions.compute_dynamics`
   Compute a :class:`oqupy.dynamics.Dynamics` object for given
-  :class:`oqupy.system.System` :class:`oqupy.system.TimeDependentSystem` and
+  :class:`oqupy.system.System` or
+  :class:`oqupy.system.TimeDependentSystem` and
   :class:`oqupy.control.Control` and
   :class:`oqupy.process_tensor.BaseProcessTensor` objects.
 

--- a/docs/pages/authors.rst
+++ b/docs/pages/authors.rst
@@ -40,6 +40,10 @@ For a complete list of *all* code contributors see
 `the contributors list <https://github.com/tempoCollaboration/TimeEvolvingMPO/graphs/contributors>`_
 on GitHub.
 
+**Version ?.?.0**
+  - `Piper Fowler-Wright <https://github.com/piperfw>`_: Open quantum systems
+    with mean-field evolution [FowlerWright2021]
+
 **Version 0.2.0**
   - `Gerald E. Fux <https://github.com/gefux>`_: Chains of open quantum systems [Fux2022].
   - `Dominic Gribben <https://github.com/djgribben>`_: Bath dynamics extension [Gribben2021a].

--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -218,7 +218,6 @@ def _compute_dynamics_all(
     states = []
     if with_field:
         fields = []
-        field = initial_field
 
     for step in range(num_steps+1):
         # -- apply pre measurement control --
@@ -236,8 +235,11 @@ def _compute_dynamics_all(
             state_tensor = _apply_caps(current_node, current_edges, caps)
             state = state_tensor.reshape(hs_dim, hs_dim)
         if with_field:
+            if step == 0:
+                field = initial_field
+            else:
+                field = compute_field(step, previous_state, field, state)
             previous_state = state
-            field = compute_field(step, previous_state, field, state)
         if record_all:
             states.append(state)
             if with_field:

--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -181,20 +181,30 @@ def _compute_dynamics_all(
             second_step = expm(system.liouvillian(t+dt*3.0/4.0)*dt/2.0)
             return first_step, second_step
     elif isinstance(system, TimeDependentSystemWithField):
-        def propagators(step: int, state: ndarray, field: complex):
-            t = start_time + step * dt
-            liouvillian = lambda tau: system.liouvillian(t, tau, state, field)
-            first_step = expm(integrate.quad_vec(liouvillian,
-                                                 a=t,
-                                                 b=t+dt/2.0,
-                                                 epsrel=epsrel,
-                                                 limit=subdiv_limit)[0])
-            second_step = expm(integrate.quad_vec(liouvillian,
-                                                  a=t+dt/2.0,
-                                                  b=t+dt,
-                                                  epsrel=epsrel,
-                                                  limit=subdiv_limit)[0])
+        if subdiv_limit is None:
+            def propagators(step: int, state: ndarray, field: complex):
+                t = start_time + step * dt
+            first_step = expm(system.liouvillian(t+dt/4.0, state,
+                field)*dt/2.0)
+            second_step = expm(system.liouvillian(t+dt*3.0/4.0, state,
+                field)*dt/2.0)
             return first_step, second_step
+        else:
+            def propagators(step: int, state: ndarray, field: complex):
+                t = start_time + step * dt
+                liouvillian = lambda tau: system.liouvillian(t, tau, state,
+                        field)
+                first_step = expm(integrate.quad_vec(liouvillian,
+                                                     a=t,
+                                                     b=t+dt/2.0,
+                                                     epsrel=epsrel,
+                                                     limit=subdiv_limit)[0])
+                second_step = expm(integrate.quad_vec(liouvillian,
+                                                      a=t+dt/2.0,
+                                                      b=t+dt,
+                                                      epsrel=epsrel,
+                                                      limit=subdiv_limit)[0])
+                return first_step, second_step
 
     # -- prepare compute field --
     if with_field:

--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -184,11 +184,11 @@ def _compute_dynamics_all(
         if subdiv_limit is None:
             def propagators(step: int, state: ndarray, field: complex):
                 t = start_time + step * dt
-            first_step = expm(system.liouvillian(t+dt/4.0, state,
-                field)*dt/2.0)
-            second_step = expm(system.liouvillian(t+dt*3.0/4.0, state,
-                field)*dt/2.0)
-            return first_step, second_step
+                first_step = expm(system.liouvillian(t, t+dt/4.0, state,
+                    field)*dt/2.0)
+                second_step = expm(system.liouvillian(t, t+dt*3.0/4.0, state,
+                    field)*dt/2.0)
+                return first_step, second_step
         else:
             def propagators(step: int, state: ndarray, field: complex):
                 t = start_time + step * dt

--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -97,14 +97,16 @@ def compute_dynamics_with_field(
         epsrel: Optional[float] = INTEGRATE_EPSREL,
         subdiv_limit: Optional[int] = SUBDIV_LIMIT) -> DynamicsWithField:
     """
-    Compute the system dynamics for a given system Hamiltonian.
+    Compute the system and field dynamics for a given system Hamiltonian and
+    field equation of motion.
 
     Parameters
     ----------
-    system: ToDo
-        ToDo
+    system: TimeDependentSystemWithField
+        Object containing the system Hamiltonian and field equation of
+        motion.
     initial_field: complex
-        ToDo
+        Initial field value.
     initial_state: ndarray
         Initial system state.
     dt: float
@@ -119,15 +121,21 @@ def compute_dynamics_with_field(
         Optional control operations.
     record_all: bool
         If `false` function only computes the final state.
-    epsrel: ToDo
-        ToDo
-    subdiv_limit: ToDo
-        ToDo
+    subdiv_limit: int (default = config.SUBDIV_LIMIT)
+        The maximum number of subdivisions used during the adaptive
+        algorithm when integrating the system Liouvillian. If None
+        then the Liouvillian is not integrated but sampled twice to
+        to construct the system propagators at each timestep.
+    epsrel: float (default = config.INTEGRATE_EPSREL)
+        The relative error tolerance for the adaptive algorithm
+        when integrating the system Liouvillian.
 
     Returns
     -------
     dynamics_with_field: DynamicsWithField
-        ToDo
+        The system and field dynamics for the given system Hamiltonian and
+        field equation of motion (accounting for the interaction with the
+        environment).
     """
     initial_field = check_convert(initial_field, complex, "initial_field")
     dynamics_with_field = _compute_dynamics_all(
@@ -149,7 +157,8 @@ def _compute_dynamics_all(
         record_all: bool,
         epsrel: float,
         subdiv_limit: int) -> Union[Dynamics,DynamicsWithField]:
-    """ToDo. """
+    """Compute system and (optionally) field dynamics accounting for the 
+    interaction with the environment using the process tensor."""
 
     # -- input parsing --
     parsed_parameters = _compute_dynamics_input_parse(

--- a/oqupy/system.py
+++ b/oqupy/system.py
@@ -239,11 +239,11 @@ class TimeDependentSystemWithField(BaseSystem):
 
     .. math::
 
-    \frac{d}{dt}\rho(t)=&-i[\hat{H}(t,\langle a\rangle),\rho(t)]\\
-        &+ \sum_n^N \gamma_n(t) \left(
-         \hat{A}_n(t) \rho(t) \hat{A}_n(t)^\dagger
-         - \frac{1}{2} \hat{A}_n^\dagger(t) \hat{A}_n(t) \rho(t)
-         - \frac{1}{2} \rho(t) \hat{A}_n^\dagger(t) \hat{A}_n(t)\right)
+        \frac{d}{dt}\rho(t) = &-i [\hat{H}(t, \langle a \rangle), \rho(t)] \\
+            &+ \sum_n^N \gamma_n(t) \left(
+                \hat{A}_n(t) \rho(t) \hat{A}_n(t)^\dagger
+                - \frac{1}{2} \hat{A}_n^\dagger(t) \hat{A}_n(t) \rho(t)
+                - \frac{1}{2} \rho(t) \hat{A}_n^\dagger(t) \hat{A}_n(t) \right)
 
     with the  `hamiltionian` :math:`\hat{H}(t, \langle a \rangle)`
     depending on both time :math:`t` and `field` :math:`\langle

--- a/oqupy/tempo/tempo.py
+++ b/oqupy/tempo/tempo.py
@@ -658,6 +658,11 @@ class TempoWithField(BaseTempo):
 
         return self._dynamics
 
+    def get_dynamics(self) -> DynamicsWithField:
+        """Returns DynamicsWithField instance associated with the Tempo object.
+        """
+        return self._dynamics
+
 def _check_time(end_time):
     """input check on end time of a tempo computation"""
     try:

--- a/oqupy/tempo/tempo.py
+++ b/oqupy/tempo/tempo.py
@@ -615,7 +615,7 @@ class TempoWithField(BaseTempo):
     def compute(
             self,
             end_time: float,
-            progress_type: Text = None) -> Dynamics:
+            progress_type: Text = None) -> DynamicsWithField:
         """
         Propagate (or continue to propagate) the TEMPO tensor network and
         coherent field to time `end_time`.

--- a/tests/coverage/tempo/pt_tempo_test.py
+++ b/tests/coverage/tempo/pt_tempo_test.py
@@ -174,6 +174,7 @@ def test_compute_dynamics_with_field():
                 np.eye(2),
                 dt = 0.2,
                 )
+    with pytest.raises(TypeError):
         tempo.compute_dynamics_with_field(
             system,
             None,
@@ -181,12 +182,13 @@ def test_compute_dynamics_with_field():
             dt = 0.2,
             )
     # Wrong system type
-    tempo.compute_dynamics_with_field(
-            tempo.TimeDependentSystem(lambda t: 0.5 * t * np.eye(2)),
-            initial_field,
-            np.array([[0.5,-0.51j],[0,-.25]]),
-            dt = 0.2,
-            num_steps = num_steps,
-            start_time = start_time
-            )
+    with pytest.raises(TypeError):
+        tempo.compute_dynamics_with_field(
+                tempo.TimeDependentSystem(lambda t: 0.5 * t * np.eye(2)),
+                initial_field,
+                np.array([[0.5,-0.51j],[0,-.25]]),
+                dt = 0.2,
+                num_steps = num_steps,
+                start_time = start_time
+                )
     

--- a/tests/physics/example_A_test.py
+++ b/tests/physics/example_A_test.py
@@ -75,7 +75,7 @@ def test_tempo_backend_A():
         tempo_params_A,
         initial_state_A,
         start_time=0.0)
-    tempo_A.compute(end_time=1.0)
+    tempo_A.compute(end_time=t_end_A)
     dyn_A = tempo_A.get_dynamics()
     np.testing.assert_almost_equal(dyn_A.states[-1], rho_A, decimal=4)
 
@@ -87,7 +87,7 @@ def test_tensor_network_pt_tempo_backend_A():
     pt = oqupy.pt_tempo_compute(
         bath_A,
         start_time=0.0,
-        end_time=1.0,
+        end_time=t_end_A,
         parameters=tempo_params_A)
 
     dyn = oqupy.compute_dynamics(

--- a/tests/physics/example_G_test.py
+++ b/tests/physics/example_G_test.py
@@ -1,0 +1,89 @@
+#Copyright 2020 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the time_evovling_mpo.backends.tensor_network modules.
+"""
+import numpy as np
+
+import oqupy
+from oqupy import process_tensor
+from oqupy import operators
+
+# -- Test G: Dicke model --
+
+initial_state_G = np.array([[0.5, 0.5], [0.5, 0.5]])
+initial_field_G = 1.0
+
+t_end_G = 1.0
+
+# Final state and field obtained from original implementation in tempo-py code
+# See tempo-py/src/pfw1/examples/example_G_test.py
+rho_G = np.array([[0.6245009+3.19373236e-15j,0.14243496-2.19523032e-01j],
+ [0.14243496+2.19523032e-01j,0.3754991 -2.26692588e-15j]])
+field_G = 0.10602369935009-0.46986388684474406j
+
+
+h_sys_G = lambda t, field: 0.5 * operators.sigma("z")  \
+        + np.real(field) * operators.sigma("x")
+field_eom_G = lambda t, state, field: -(1j + 1) * field \
+        - 0.5j * np.matmul(operators.sigma("x"), state).trace().real
+
+correlations_G = oqupy.PowerLawSD(alpha=0.1,
+                                  zeta=1.0,
+                                  cutoff=5.0,
+                                  cutoff_type="gaussian",
+                                  temperature=0.0,
+                                  name="ohmic")
+bath_G = oqupy.Bath(0.5 * operators.sigma("z"),
+                    correlations_G,
+                    name="phonon bath")
+system_G = oqupy.TimeDependentSystemWithField(
+        h_sys_G,
+        field_eom_G)
+tempo_params_G = oqupy.TempoParameters(
+        dt=0.05,
+        dkmax=None,
+        epsrel=10**(-7))
+
+# -----------------------------------------------------------------------------
+
+def test_tempo_backend_G():
+    tempo_G = oqupy.TempoWithField(
+        system_G,
+        bath_G,
+        tempo_params_G,
+        initial_state_G,
+        initial_field_G,
+        start_time=0.0)
+    tempo_G.compute(end_time=t_end_G)
+    dyn_G = tempo_G.get_dynamics()
+    np.testing.assert_almost_equal(dyn_G.fields[-1], field_G, decimal=4)
+    np.testing.assert_almost_equal(dyn_G.states[-1], rho_G, decimal=4)
+
+def test_tensor_network_pt_tempo_backend_A():
+    pt = oqupy.pt_tempo_compute(
+        bath_G,
+        start_time=0.0,
+        end_time=t_end_G,
+        parameters=tempo_params_G)
+
+    dyn = oqupy.compute_dynamics_with_field(
+        system=system_G,
+        initial_field=initial_field_G,
+        process_tensor=pt,
+        initial_state=initial_state_G)
+    np.testing.assert_almost_equal(dyn.fields[-1], field_G, decimal=4)
+    np.testing.assert_almost_equal(dyn.states[-1], rho_G, decimal=4)
+
+# -----------------------------------------------------------------------------

--- a/tutorials/mf_tempo.ipynb
+++ b/tutorials/mf_tempo.ipynb
@@ -1,0 +1,601 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Time dependence and PT-TEMPO\n",
+    "Guide to using the OQuPy package to compute the dynamics of a many-body system of the type introduced in [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)). We demonstrate both the TEMPO and PT-TEMPO methods for this calculation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Contents:**\n",
+    "\n",
+    "* Example - Dicke Hamiltonian under the rotating wave approximation\n",
+    "    1. Many-body system and environment Hamiltonian\n",
+    "    2. System Hamiltonian and field equation of motion after the mean-field reduction\n",
+    "    3. Create time dependent system with field object\n",
+    "    4. TEMPO computation for single dynamics\n",
+    "    5. PT-TEMPO computation for multiple sets of dynamics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, import OQuPy and other relevant packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'tensornetwork'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [2]\u001b[0m, in \u001b[0;36m<cell line: 4>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01msys\u001b[39;00m\n\u001b[1;32m      2\u001b[0m sys\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39minsert(\u001b[38;5;241m0\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m..\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mmatplotlib\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mpyplot\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mplt\u001b[39;00m\n",
+      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/__init__.py:56\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[38;5;66;03m# -- Modules in alphabetical order --------------------------------------------\u001b[39;00m\n\u001b[1;32m     54\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Bath\n\u001b[0;32m---> 56\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath_dynamics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m TwoTimeBathCorrelations\n\u001b[1;32m     58\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcontractions\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m compute_correlations\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcontractions\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m compute_dynamics\n",
+      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/bath_dynamics.py:28\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m ndarray\n\u001b[1;32m     27\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbase_api\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseAPIClass\n\u001b[0;32m---> 28\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mprocess_tensor\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseProcessTensor\n\u001b[1;32m     29\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Bath\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01msystem\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseSystem\n",
+      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/process_tensor.py:30\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[1;32m     29\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m ndarray\n\u001b[0;32m---> 30\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtensornetwork\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mtn\u001b[39;00m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mh5py\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbase_api\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseAPIClass\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'tensornetwork'"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0,'..')\n",
+    "\n",
+    "import oqupy\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the installed OQuPy version; TEMPO with mean-field evolution was introduced in **?.?.0**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.2-dev'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oqupy.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following matrices will be useful below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'oqupy' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [3]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m sigma_z \u001b[38;5;241m=\u001b[39m \u001b[43moqupy\u001b[49m\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mz\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m sigma_plus \u001b[38;5;241m=\u001b[39m oqupy\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m+\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      3\u001b[0m sigma_minus \u001b[38;5;241m=\u001b[39m oqupy\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m-\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'oqupy' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "sigma_z = oqupy.operators.sigma(\"z\")\n",
+    "sigma_plus = oqupy.operators.sigma(\"+\")\n",
+    "sigma_minus = oqupy.operators.sigma(\"-\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-------------------------------------------------\n",
+    "## Example - Dicke Hamiltonian under the rotating wave approximation\n",
+    "\n",
+    "Our goal will be to reproduce **Fig. 2a.** of [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)), firstly using TEMPO to obtain a single line from this figure, and then PT-TEMPO to obtain all lines in short succession. \n",
+    "\n",
+    "### 1. Many-body system and environment Hamiltonian\n",
+    "The Hamiltonian describing the many-body system with one-to-all light-matter coupling is\n",
+    "$$\n",
+    "H_{S} = \\omega_c a^{\\dagger}_{}a^{\\vphantom{\\dagger}}_{} \n",
+    "\t+ \\sum_{i=1}^N \\left[\\frac{\\omega_0}{2} \\sigma^z_i\n",
+    "\t+  \\frac{\\Omega}{2\\sqrt{N}} \\left( a^{\\vphantom{\\dagger}}_{} \\sigma^+_i + a^{\\dagger}_{} \\sigma^-_i \\right)\\right]\n",
+    "$$\n",
+    "Together with the vibrational environment of each molecule,\n",
+    "$$\n",
+    "\tH_{E}^{(i)} = \\sum_{j} \\left[\t\\nu_{j} b^{\\dagger}_{j} b^{\\vphantom{\\dagger}}_{j} \n",
+    "\t+ \\frac{\\xi_{j}}{2} (b^{\\vphantom{\\dagger}}_{j}+b^{\\dagger}_{j})\\sigma^z_i\\right]\\text{,}\n",
+    "$$\n",
+    "which is taken to be a continuum of low frequency modes with coupling characterized by a spectral density \n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "J(\\nu) &= \\sum_{j}  \\left(\\frac{\\xi_j}{2}\\right)^2\n",
+    "\\delta(\\nu-\\nu_j) \\\\\n",
+    "&= 2\\alpha \\nu e^{-(\\nu/\\nu_c)^2}\\text{,} \\quad \\nu>0\\text{,}\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "where $\\alpha=0.25$ and $\\nu_c=0.15$ eV for the environment of BODIPY-Br considered in the Letter. Other system and environment parameters relevant to **Fig. 2a.** are, in units of eV,\n",
+    "* $T=0.026$ ($300$ K) - environment temperature\n",
+    "* $\\omega_0=0$ - two-level system frequency**\\***\n",
+    "* $\\omega_c=-0.02$ - bare cavity frequency\n",
+    "* $\\Omega=0.2$ - collective light-matter coupling\n",
+    "\n",
+    "together with the rates\n",
+    "* $\\kappa=0.01$ - field decay\n",
+    "* $\\Gamma_\\downarrow = 0.01$ - electronic dissipation\n",
+    "* $\\Gamma_\\uparrow \\in (0.2\\Gamma_\\downarrow,0.8\\Gamma_\\downarrow) $ - electronic pumping\n",
+    "\n",
+    "which appear as prefactors for Markovian terms in the quantum master equation for the total density operator\n",
+    "$$\n",
+    "\t\t\\partial_t \\rho = -i \\biggl[ H_S + \\sum_{i=1}^N H_E^{(i)}, \\rho \\biggr]\n",
+    "\t+ 2 \\kappa \\mathcal{L}[a^{\\vphantom{\\dagger}}_{}]\n",
+    "\t+ \\sum_{i=1}^N (\\Gamma_\\uparrow \\mathcal{L}[\\sigma^+_i]\n",
+    "\t+  \\Gamma_\\downarrow \\mathcal{L}[\\sigma^-_i])\\text{.}\n",
+    "$$\n",
+    "As indicated, it is the pump strength $\\Gamma_\\uparrow$ that will be varied to generate the different lines of **Fig. 2a.** All other parameters are defined in the following code box.\n",
+    "\n",
+    "\n",
+    "**\\***N.B. for calculating the dynamics only the detuning $\\omega_c-\\omega_0$ is relevant, so we set $\\omega_0=0$ for conveninence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alpha = 0.25\n",
+    "nu_c = 0.15\n",
+    "T = 0.026\n",
+    "omega_0 = 0\n",
+    "omega_c = -0.02\n",
+    "Omega = 0.2\n",
+    "\n",
+    "kappa = 0.01\n",
+    "Gamma_down = 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. System Hamiltonian and field equation of motion after the mean-field reduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The mean-field approach is based on the product-state ansatz\n",
+    "$$\n",
+    "\\rho = \\rho_a \\otimes \\bigotimes_{i=1}^N \\rho_i\n",
+    "$$ \n",
+    "where $\\rho_a= \\text{Tr}_{\\otimes{i}}\\rho$ is obtained from the partial trace taken over the Hilbert space of all two-level systems and $ \\rho_i = \\text{Tr}_{a, \\otimes{j\\neq i}} \\rho$ from the partial trace over all but the photonic degree of freedom. As detailed in the Supplemental Material of the Letter, after rescaling the field $\\langle a \\rangle \\to \\langle a \\rangle/\\sqrt{N}$ ($\\langle a \\rangle$ scales with $\\sqrt{N}$ in the lasing phase), the dynamics are controlled by the mean-field Hamiltonian $H_{\\text{MF}}$ for a *single molecule,*\n",
+    "$$\n",
+    "\tH_\\text{MF} = \n",
+    " \\frac{\\omega_0}{2}\\sigma^z+\n",
+    "\t\\frac{\\Omega}{2}\\left( \\langle a \\rangle \\sigma^+ +\n",
+    "\t\\langle a \\rangle^{*}\\sigma^- \\right)\\text{,}\n",
+    "$$\n",
+    "together with the equation of motion for the field $\\langle a \\rangle$,\n",
+    "$$\n",
+    "\\partial_t \\langle a \\rangle = \n",
+    "\t- (i\\omega_c+\\kappa)\\langle a \\rangle- i \\frac{\\Omega}{2}\\langle\\sigma^-\\rangle.\n",
+    "$$\n",
+    "To encode this information, and hence compute the dynamics, we use a `TimedependentSystemWithField` object. In the following we use $\\rho$ (no subscript) to denote the density operator of a a single two-level system (rather than the total many-body operator), since this forms the system in our TEMPO simulations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Create time dependent system with field object\n",
+    "The `TimedependentSystemWithField` object requires two physical inputs: a Hamiltonian, which is a function of time $t$ and field value $\\langle a \\rangle$ (in that order), and a equation of motion for the field, which is a function of time $t$, two-level system state $\\rho$ and field value $\\langle a \\rangle$. Note here $\\rho$ is provided as a $2\\times2$ matrix, hence to compute the expectation $\\langle \\sigma^- \\rangle$ we must multiple $\\rho$ by $\\sigma^-$ and take the trace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def H_MF(t, a):\n",
+    "    return 0.5 * omega_0 * sigmaz +\\\n",
+    "        0.5 * Omega * (a * sigma_plus + np.conj(a) * sigma_minus)\n",
+    "def field_eom(t, state, a):\n",
+    "    expec_val = np.matmul(sigma_minus, state).trace().real\n",
+    "    return -(1j * omega_c + kappa) * a - 0.5j * Omega * expect_val\n",
+    "    \n",
+    "\n",
+    "system = oqupy.TimeDependentSystem(hamiltonian_t)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, we need to specify Lindland operators for the pumping and dissipation processes. For now we will use a pumping $\\Gamma_\\uparrow = 0.8 \\Gamma_\\downarrow$, but in the PT-TEMPO computation below this will be varied."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Gamma_up = 0.8 * Gamma_down\n",
+    "gammas = [ lambda t: Gamma_down, lambda t: Gamma_up]\n",
+    "lindblads = [ lambda t: sigma_minus, lambda t: sigma_plus]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the rates and linblad operators must be callables taking a single argument---time---even though in our example there is no time-dependence (there is no `SystemWithField` class). Including the above, the system is then constructed with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system = oqupy.TimeDependentSystemWithField(\n",
+    "        H_MF,\n",
+    "        field_eom,\n",
+    "        gammas=gammas,\n",
+    "        lindblad_operators=lindblads)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Correlations and a Bath object are created in the same way as in any other TEMPO computation (see preeceding tutorials):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correlations = oqupy.PowerLawSD(alpha=alpha,\n",
+    "                                zeta=1,\n",
+    "                                cutoff=nu_c,\n",
+    "                                cutoff_type='gaussian',\n",
+    "                                temperature=temperature)\n",
+    "bath = oqupy.Bath(0.5 * sigma_z, correlations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. TEMPO computation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our simulations we use the same initial conditions for the system and state used in the Letter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initial_field = np.sqrt(0.05) # Note n_0 = <a^dagger a>(0) = 0.05\n",
+    "initial_state = np.array([[0,0],[0,1]]) # spin down"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "as well as the computational parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100.0%   50 of   50 [########################################] 00:00:01\n",
+      "Elapsed time: 1.4s\n"
+     ]
+    }
+   ],
+   "source": [
+    "tempo_parameters = oqupy.TempoParameters(dt=0.6, dkmax=250, epsrel=10**(-4))\n",
+    "start_time = 0.0\n",
+    "end_time = 1000.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where for the sake of reducing the computation time the precision was lowered and the simulation time halved relative to the Letter. The only sutblty here is that the units of time are those with $\\hbar=1$; you can check $t=1000$ corresponds to $t=4$ ps in SI units.\n",
+    "`oqupy.TempoWithField` and the `.compute` method may then be used to compute the dynamics in exactly the same way a call to `oqupy.Tempo` is used to compute the dynamics for an ordinary `System` or `TimeDependentSystem`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tempo_sys = oqupy.Tempo(system=system,\n",
+    "                        bath=bath,\n",
+    "                        initial_state=initial_state,\n",
+    "                        start_time=start_time,\n",
+    "                        parameters=tempo_parameters)\n",
+    "dynamics_with_field = tempo_sys.compute(end_time=end_time)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note `dynamics_with_field` contains both the timesteps and state matrices at each timestel, plus the corresponding field values. We plot the latter below which describes (part of) a single curve from **Fig. 2.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f530c8b5f28>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEMCAYAAAArnKpYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAgQklEQVR4nO3deZScdZ3v8fe39zXdWbqzdAfSIRAISACbRZRFwAGiDupcBJ3rAiriAUfv9dyRmXEGHeac8aqjzAjCRVzPlUSvgiKyDDDKIiKEJIQlAUIHk+okvdF7d1Vv3/tHVbdNp0Oqq6ue2j6vc/p0PUtVfytLffr3PL/F3B0RERGAgnQXICIimUOhICIiUxQKIiIyRaEgIiJTFAoiIjJFoSAiIlMCCQUz+76ZtZvZ84c4bmb2H2a2y8y2m9kpQdQlIiJvFFRL4YfARW9y/GLg6NjXVcAtAdQkIiIzBBIK7v4o8PqbnHIJ8GOPehKoNbPlQdQmIiJ/VpTuAmIagL3TtkOxfftnnmhmVxFtTVBZWfnWY489NpACRURyxTPPPNPp7nWzHcuUULBZ9s06/4a73wbcBtDc3OybN29OZV0iIjnHzP50qGOZ0vsoBKyctt0I7EtTLSIieStTQuFu4KOxXkhnAL3uftClIxERSa1ALh+Z2UbgXGCJmYWA64FiAHe/FbgX2ADsAoaAK4KoS0RE3iiQUHD3Dx3muAPXBFGLiIgcWqZcPhIRkQygUBARkSkKBRERmaJQEBGRKQoFERGZkikjmkXSbnR8gm17e6guK2JRZQmLKkooKtTvTZJfFAoiMbf87lW++eDLb9hXW1HM4soSGhdW8D/fdQzrV9ampziRgCgURIDw6Dg/euI13rZ6Mf/9jCN5fTBC58AIXYMRXh8cYfNr3Xzglif4zDlH8dnz11BaVJjukkVSQqEgAty1tZWuwRH+5vyjedtRiw863js8yg33vMhNv93FQzva+Mal6zmhoSYNlYqkli6YSt6bmHBuf6yFExoWcMbqRbOeU1NezDcuXc/3PtZM1+AI77v599z40MuMjk8EXK1IaikUJO/99qV2Xu0Y5FNnrcZstlnc/+z845by4P84m/euX8GND73CJTf9npcO9AdUqUjqKRQk7333sRaW15Sx4S3xLfZXW1HCty47if/zkbfS3h/mvd9+nNsfa2FiYtYlQESyikJB8tpzoV6ebHmdK9/eRPEcu59eePwy7v/82Zx9TB3/8psd/PXtf6S1ZzhFlYoEQ6Egee27j7VQVVrEZaetPPzJs1hSVcp3P/pWvvZXJ7I91MNFNz7KL7e2Ep34VyT7KBQkb7X2DPOb5/Zz+akrWVBWnPDrmBkfPHUl933ubNYurebzP93GtRu30jkQSWK1IsFQKEje+uHvdwNwxTuakvJ6Ryyu4Keffhv/68K1PPD8Ad759d9x+2MtjIyph5JkD41TkLzUFx5l41N7efdbltNQW5601y0sMK555xouPH4ZN9zzIv/ymx3c8dQe/vE963jn2vqk/RzJLe7OyPgEkbEJIqMTRMbGD348NkFk9M+Pj1laxYmNtUmvRaEgeemnT+1lIDLGp85anZLXX1NfxQ+vOJXfvtTODffs4IofPM15x9bzpXcfx+q6qpT8TElcIh/KkbHx2PF4zj/8683Vp89ZrVAQSYbR8Ql+8PvdnN60iLc0pm5Usplx3rFLeceaOn70xGv8+8OvcOGNj3LJSQ18/MxVGhH9Jtyd4dFxBiPjDI2MTX0fGhknPDrO8Gj0A3l4NLodjn3Yhqd96IanfeCOpOBDeaaSwgJKiwooLS6gpLCAsuJCSopi+4oKqSotYlFFdP/keaVF0cclRdP3x75Pfk1tR7+XxZ5XU5H4fbA3o1CQvHPf8wfY1xvmhvedEMjPKykq4FNnr+Z9Jzfw7f96hZ8/E+Lnz4Q45YhaPnbmKi4+YTklRbl3e29sfILuoVG6BiN0D47SOzxCz9AoPcOj9AxFt/vCY/SHx+gPjzIw7fHQ6Dhz7cBVVGBTH6yT30umfahWlRaxpGra/qKDP5wP/lAujB4v/PP+slk+zEsKCygoePOBj9nCsrnrXHNzs2/evDndZUiW+dIvn+PubfvY9k9/kZb/yL3Do/zimRA//sNrvNY1xJKqUj58+hH85foVHFVXedhR1enk7vRHxmjvC9PWF6G9P/q9rS9Me3+EroEIXQMjdA2O0D00csgP9uJCo6a8hAXlRVSXFbOgrIiq0iKqy6LblaVFVJYUUjH5vaSQ8pKi6PfiQsqKCykrLph6XFpUoGnO58DMnnH35tmOqaUgeaelY5DVdVVp+82upryYK9/RxMfPXMWjr3Twoyde49v/9Qr/8fArLFtQxtvXLOEdRy/m7UctoX5BWWB1uTt9w2Ps7xtmf2+Y/T1hDvQOs683zIHeMPt7o/uHRsYPem5VaRF11aXUVZWypr6K06tKWFxZypKqEhZVlrKwopjaihJqK4qprSimvLgwo8MvnykUJO/s7hzkbasPngk1aAUFxrlr6zl3bT2h7iEefbmT3+/q5OGdbfxiSwiAY5ZWccKKGhoXVbByYTmNCytYuaic5TXlFMYRapPX5gciY/QOjdLRH6FjIBL9Hvtq6w+zP/bBP/MDv8CgvrqM5bVlrF1WzTnH1LOsppSlC8pYuqCM+upS6heUUVWqj5Jcob9JyStDI2Ps7w2zuq4y3aW8QePCCj58+hF8+PQjmJhwXtzfx+O7oiHxh5YuDmxrfcOlmKICY0F5MUUFRnFhAUWFNvV4fMIZiIwxEBljMDLGoaZkKikqoL66lLrqUo5btoB3rq1neU0Zy2vKWVZTxvKa6Ie+LsvkF4WC5JXdnYMANC3J3G6hBQXGCQ01nNBQw9XnHAXAyNgE+3qGCXUPs7d7iL2vD9EXHmVs3Bkdd8YmJmKPJygsMKpKi6gsjV6nryqLPq4pL6auKhoCddWlLCgr0iUcOYhCQfJKS0c0FDKtpXA4JUUFrFpSyaol2VW3ZB+1CyWvTLYUVi3Wh6vIbBQKkldaOgZoqC2nvERrLIvMRqEgeWV35yBNugQjckgKBckb7h4bo6BQEDkUhYLkjc6BEfojY2opiLwJhYLkjZaOAQDNUiryJhQKkjcmex6tVktB5JAUCpI3WjoHKSkqYEUSF9URyTUKBckbLR2DrFpcEdecQSL5KrBQMLOLzOwlM9tlZtfNcrzGzH5tZs+a2QtmdkVQtUl+aOkcYHUGT28hkgkCCQUzKwRuBi4G1gEfMrN1M067BnjR3dcD5wL/ZmYlQdQnuW90fII9XUPqjipyGEG1FE4Ddrl7i7uPAJuAS2ac40C1RWfoqgJeB8YCqk9yXKh7mLEJV3dUkcMIKhQagL3TtkOxfdPdBBwH7AOeAz7n7gctnGpmV5nZZjPb3NHRkap6JceoO6pIfIIKhdnu7M2c5f1CYBuwAjgJuMnMFhz0JPfb3L3Z3Zvr6uqSXafkKHVHFYlPUKEQAlZO224k2iKY7grgTo/aBewGjg2oPslxr3YMsrCimIWVuk0l8maCCoWngaPNrCl28/hy4O4Z5+wBzgcws6XAWqAloPokx+3uHND9BJE4BBIK7j4GXAs8AOwAfubuL5jZ1WZ2dey0G4Azzew54GHgi+7eGUR9kvuiE+HpfoLI4QS28pq73wvcO2PfrdMe7wP+Iqh6JH8MRMZo74+opSASB41olpy3O7YE51EaoyByWAoFyXktndHuqE0azSxyWAoFyXktHYOYwZGLK9JdikjGUyhIztvdOUhDbTllxVqXWeRwFAqS81o6B9TzSCROCgXJae7O7o5BjWQWiZNCQXJae3+EwZFxzY4qEieFguS0llh3VI1REImPQkFy2mR3VN1TEImPQkFy2u6OQcqKC1i+oCzdpYhkBYWC5LSWzkFWLa6kQOsyi8RFoSA5bXfnoG4yi8yBQkFy1sjYBHteH2K1prcQiZtCQXLW3u4hxrUus8icKBQkZ012R9XlI5H4KRQkZ+2e7I6qy0cicVMoSM56rWuIhRXF1FQUp7sUkayhUJCc1dYbZnlNebrLEMkqCgXJWW39YZYuKE13GSJZRaEgOetAb4RlNRrJLDIXCgXJSaPjE3QNRqivViiIzIVCQXJS50AEd1iqOY9E5kShIDmprS8CoHsKInOkUJCcdKA3DKilIDJXCgXJSe39CgWRRCgUJCe19YUpLDAWV5akuxSRrKJQkJzU1hehvrpU6yiIzJFCQXJSW19Yl45EEqBQkJwUDQX1PBKZK4WC5KS2vohaCiIJUChIzgmPjtM7PKpQEEmAQkFyTnts4Fp9tS4ficyVQkFyzoG+6BgFTYYnMncKBck5bX0auCaSqMBCwcwuMrOXzGyXmV13iHPONbNtZvaCmT0SVG2SW6ZCQTOkisxZURA/xMwKgZuBdwEh4Gkzu9vdX5x2Ti3wHeAid99jZvVB1Ca5p70/QmlRAQvKA/nnLZJTgmopnAbscvcWdx8BNgGXzDjnw8Cd7r4HwN3bA6pNcsyB3jDLasow02hmkbkKKhQagL3TtkOxfdMdAyw0s9+Z2TNm9tHZXsjMrjKzzWa2uaOjI0XlSjZr6wvr0pFIgoIKhdl+ZfMZ20XAW4F3AxcC/2hmxxz0JPfb3L3Z3Zvr6uqSX6lkvfb+CPUazSySkKBCIQSsnLbdCOyb5Zz73X3Q3TuBR4H1AdUnOcLdNe+RyDwEFQpPA0ebWZOZlQCXA3fPOOdXwFlmVmRmFcDpwI6A6pMc0R8ZY2hknGUKBZGEBNI9w93HzOxa4AGgEPi+u79gZlfHjt/q7jvM7H5gOzAB3O7uzwdRn+SO9lh3VF0+EknMnELBzJqB7bEeRHPi7vcC987Yd+uM7a8DX5/ra4tM+vPazGopiCQi7stHZrYceAL4YOrKEZkfjWYWmZ+53FP4GPAj4JMpqkVk3g5MhYIuH4kkYi6h8BHg74ASMzsqRfWIzEt7X4TqsiIqSjSaWSQRcYWCmb0T2BnrKvoD4BMprUokQeqOKjI/8bYUPgF8L/b4p8ClZqYZViXjaBlOkfk57Ad7bKK6M4D7ANy9D3gS2JDSykQSoGU4RebnsBde3b0HWDNj30dSVZBIoiYmnPZ+XT4SmQ9dApKc0T00wui4s1TLcIokLN4bzQ+ZmeYhkoymgWsi8xdvS+FvgW+Z2Q9ig9hEMk5bf2yMgtZmFklYXKHg7lvc/TzgHuB+M7vezMpTW5rI3LT1ajSzyHzNZZoLA14CbgE+C7xiZrrhLBlj8vJRXZXuKYgkKt57Co8DrcC3iK6Y9nHgXOA0M7stVcWJzEVbf5jFlSWUFKn/hEii4p0L4GrgBXefuVraZ81Max5IRmjXaGaReYv3nsLzk4FgZoUzDr876VWJJOCARjOLzFsi7ezbYiujYWZnu3tLkmsSSYhGM4vMXyJTSf4T8D0zGwO2EV1LWSStxsYn6ByIUK9QEJmXRFoKNxDtheTAz5JbjkhiOgdGcNc6CiLzFW/vo+unbf6tu38Z+Axw/ezPEAnW5Ipry9RSEJmXeC8fXR+7j7AI2GJmm9y928w+ncLaROJ2QMtwiiRFvJePHAgDDwArgSfMbL27j6esMpE5aI+FQr0uH4nMS7wthZ3uPnmp6Odm9kPgVuC8lFQlMkdtfREKC4zFlQoFkfmIt6XQaWZvndxw95eButSUJDJ3bX1h6qtLKSywdJciktXibSn8DbDJzJ4BngNOBHanrCqROTrQF1Z3VJEkiHdE87PAScDG2K7fAh9KUU0ic9beF9HiOiJJEPfgNXePAL+JfYlklLb+MKc1LUp3GSJZT9NJStYLj47TMzTKMi2uIzJvCgXJeu2xdRTqdflIZN4OGwpmVjFzfWYzO8LMGlJXlkj8ppbh1I1mkXmLp6UwCtxpZpXT9t0OaK1myQhtGs0skjSHDQV3HwXuAi6DaCsBqHP3zSmuTSQuk8twat4jkfmL957C7cAVsccfBX6QmnJE5q6tL0xpUQELyhOZCV5Epovrf5G77zQzzOwYouMT3pHaskTi19YXpn5BKWYazSwyX3PpffQ9oi2G7e7enaJ6ROZsX88wK2rK012GSE6YSyj8DFhPNBxEMkZr9zANCxUKIskQdyi4+5C717j7Q4n8IDO7yMxeMrNdZnbdm5x3qpmNm9l/S+TnSH4ZHZ/gQF+YhlqFgkgyBDJ4zcwKgZuBi4F1wIfMbN0hzvvfRNdtEDmstr4wE45CQSRJghrRfBqwy91b3H0E2ARcMst5nwV+AbQHVJdkudbuYQBdPhJJkqBCoQHYO207FNs3JTZC+v1EF+85JDO7ysw2m9nmjo6OpBcq2aW1JxYKaimIJEVQoTBbX0GfsX0j8MXDLfHp7re5e7O7N9fVaZ2ffDfZUlihUBBJiqBG+4SIru08qRHYN+OcZqIL+QAsATaY2Zi7/zKQCiUrtfYMs6SqlLLiwnSXIpITggqFp4GjzawJaAUuBz48/QR3b5p8HFsD+h4FghxOa4+6o4okUyCXj9x9DLiWaK+iHcDP3P0FM7vazK4OogbJTa3dwzTq0pFI0gQ2WYy73wvcO2PfrDeV3f3jQdQk2c3dae0Z5oJ1S9NdikjO0CI7krU6B0aIjE2o55FIEikUJGtNdkdVzyOR5FEoSNaaGrimUBBJGoWCZK19PRrNLJJsCgXJWq09w1SXFlFTXpzuUkRyhkJBslZIU2aLJJ1CQbJWa8+w7ieIJJlCQbJWa/eQWgoiSaZQkKzUHx6lLzymloJIkikUJCu1queRSEooFCQracpskdRQKEhWmmwpaDI8keRSKEhWau0epqSwgCVVpekuRSSnKBQkK4V6hllRW0ZBwWyL+olIohQKkpX2aXEdkZRQKEhWau3WwDWRVFAoSNaJjI3T3h+hobYi3aWI5ByFgmSd/T1hQGMURFJBoSBZZ2rgmi4fiSSdQkGyzuTAtUa1FESSTqEgWSfUM4wZLF1Qlu5SRHKOQkGyTmv3MEuryygp0j9fkWTT/yrJOq09mjJbJFUUCpJ1tLiOSOooFCSrjE84B3rDaimIpIhCQbJKR3+E0XFXS0EkRRQKklVae4YADVwTSRWFgmSVULfWURBJJYWCZJXJ0cxacU0kNRQKklVau4eprSimsrQo3aWI5CSFgmQVdUcVSS2FgmQVraMgkloKBcka7h5tKajnkUjKKBQka/QMjTI0Mq6WgkgKBRYKZnaRmb1kZrvM7LpZjv+1mW2PfT1hZuuDqk2yw2TPI02ZLZI6gYSCmRUCNwMXA+uAD5nZuhmn7QbOcfcTgRuA24KoTbLHnxfX0TKcIqkSVEvhNGCXu7e4+wiwCbhk+gnu/oS7d8c2nwQaA6pNssTk4jq6pyCSOkGFQgOwd9p2KLbvUD4B3DfbATO7ysw2m9nmjo6OJJYoma61Z5jy4kIWVhSnuxSRnBVUKNgs+3zWE83eSTQUvjjbcXe/zd2b3b25rq4uiSVKpmvtjvY8Mpvtn5OIJENQw0JDwMpp243AvpknmdmJwO3Axe7eFVBtkiVe7RjgyEW6nyCSSkG1FJ4GjjazJjMrAS4H7p5+gpkdAdwJfMTdXw6oLskSvcOjvNI+wEkra9NdikhOC6Sl4O5jZnYt8ABQCHzf3V8ws6tjx28F/glYDHwndnlgzN2bg6hPMt+ze3sAOPmIhektRCTHBTarmLvfC9w7Y9+t0x5/EvhkUPVIdtm6pwczWL+yJt2liOQ0jWiWrLBlTzfH1FdTXaaeRyKppFCQjDcx4Wzb28MpR9amuxSRnKdQkIzX0jlI7/AoJ6/U/QSRVFMoSMbbuic60F0tBZHUUyhIxtuyp4cFZUWsXlKV7lJEcp5CQTLe1j3dnHTEQgoKNJJZJNUUCpLRBiJjvNzWz8katCYSCIWCZLTte3uYcDjlSN1kFgmCQkEy2pbYTeaTGmvTW4hInlAoSEbbuqeHNfVV1Gi6bJFAKBQkY7k7W/f26H6CSIAUCpKx/tQ1xOuDI7qfIBIghYJkrMn7CScfUZveQkTySGCzpIrM1dY9PVSVFnF0fXW6S5EMNjo6SigUIhwOp7uUjFNWVkZjYyPFxfHfk1MoSMbasqeb9StrKNSgNXkToVCI6upqVq1apaVap3F3urq6CIVCNDU1xf08XT6SjDQ0MsbOA/2cokV15DDC4TCLFy9WIMxgZixevHjOLSiFgmSk7aFexidc9xMkLgqE2SXy56JQkIy0dU8PgKbLFgmYQkEy0pY93TQtqWRhZUm6SxHJKwoFyTjuztY9Pbp0JJIGCgXJOKHuYToHIpysm8ySZe666y7MjJ07d87rde6//37Wrl3LmjVr+OpXv5rwOYlQKEjGmRy0dopaCpJlNm7cSHNzM5s2bUr4NcbHx7nmmmu47777ePHFF9m4cSMvvvjinM9JlMYpSMbZuqeHipJC1i7VoDWZm6/8+gVe3NeX1Ndct2IB17/3+MOeNzAwwCOPPMKDDz7IpZdeype//OWEft5TTz3FmjVrWL16NQCXX345v/rVr1i3bt2czkmUQkEyirvzZEsXJzbWUFSohqxkj1/+8pdccMEFnHjiiVRWVrJlyxZOOeWUqeNnnXUW/f39Bz3vG9/4BhdccMHUdmtrKytXrpzabmxs5I9//OMbnhPPOYlSKEhGuWf7fnYe6OdfP/CWdJciWSie3+hTZePGjVx11VUAfPCDH2Tjxo1vCIXHHnssrtdx94P2zRxvEM85iVIoSMYYHhnnX+/dwbrlC/hg88rDP0EkQ3R1dfHUU09x5513AnDZZZdxzjnn8LWvfW3qwzrelkJjYyN79+6d2g6FQqxYseINz4nnnEQpFCRj3PrIq+zrDXPj5SdrviPJKj//+c/ZsGEDpaWlADQ1NbFs2TIef/xxzjrrLCD+lsKpp57KK6+8wu7du2loaGDTpk3ccccdcz4nUQoFyQih7iFufeRV3nPick5rWpTuckTmZOPGjWzfvp1Vq1ZN7evq6uKOO+6YCoV4FRUVcdNNN3HhhRcyPj7OlVdeyfHHRy+Lbdiwgdtvv50VK1Yc8pz5stmuTWWL5uZm37x5c7rLkCS45idbeHhnGw9/4VwaasvTXY5kkR07dnDcccelu4yMNdufj5k94+7Ns52v7h2Sdn94tYvfPLefq885SoEgkmYKBUmr8QnnK79+gYbacj599lHpLkck7ykUJK02PrWHnQf6+fsNx1FeUpjuciRLZfNl8FRK5M9FoSBp0zs0yr/950uc3rSIDW9Zlu5yJEuVlZXR1dWlYJhhcuW1srKyOT1PvY8kLcbGJ/jq/TvoHR7l+vcer0VSJGGNjY2EQiE6OjrSXUrGmVyjeS4UChKo8Og4/++ZELc9+ip7Xx/m42euYt2KBekuS7JYcXHxnNYgljcXWCiY2UXAvwOFwO3u/tUZxy12fAMwBHzc3bcEVZ+kVu/wKP/3yT/xg9/vpnNghJNW1vKld6/jXcctTXdpIjJNIKFgZoXAzcC7gBDwtJnd7e7T53q9GDg69nU6cEvsu2Qwd2fCo72IxiYm6B4apWsgQtfACJ0DEToHRtjbPcTd2/YxEBnjnGPq+My5R3F60yJdMhLJQEG1FE4Ddrl7C4CZbQIuAaaHwiXAjz16t+hJM6s1s+Xuvj/Zxdz//AG+8LNtyX7ZnDP9tt30e3iOMzEB4+6MTxz+5l55cSEXrFvK1ees5vgVNckvVESSJqhQaAD2TtsOcXArYLZzGoA3hIKZXQVcFdscMLOXEqxpCdCZ4HOzVdre807gpnT8YP095wu957k58lAHggqF2a4TzPwVM55zcPfbgNvmXZDZ5kMN885Ves/5Qe85P6TqPQc1TiEETJ8LuRHYl8A5IiKSQkGFwtPA0WbWZGYlwOXA3TPOuRv4qEWdAfSm4n6CiIgcWiCXj9x9zMyuBR4g2iX1++7+gpldHTt+K3Av0e6ou4h2Sb0ixWXN+xJUFtJ7zg96z/khJe85q6fOFhGR5NLcRyIiMkWhICIiU/I6FMzs62a208y2m9ldZlab7ppSzcwuNbMXzGzCzHK6C5+ZXWRmL5nZLjO7Lt31pJqZfd/M2s3s+XTXEgQzW2lmvzWzHbF/059Ld02pZmZlZvaUmT0be89fSfbPyOtQAB4ETnD3E4GXgb9Lcz1BeB74APBougtJpWlTq1wMrAM+ZGbr0ltVyv0QuCjdRQRoDPiCux8HnAFckwd/xxHgPHdfD5wEXBTrrZk0eR0K7v6f7j4W23yS6NiInObuO9w90VHg2WRqahV3HwEmp1bJWe7+KPB6uusIirvvn5w00937gR1EZ0HIWR41ENssjn0ltbdQXofCDFcC96W7CEmaQ02bIjnIzFYBJwN/THMpKWdmhWa2DWgHHnT3pL7nnF9PwcweAmZb1usf3P1XsXP+gWhT9CdB1pYq8bznPBDXtCmS/cysCvgF8Hl370t3Panm7uPASbF7oHeZ2QnunrT7SDkfCu5+wZsdN7OPAe8BzvccGbRxuPecJzRtSh4ws2KigfATd78z3fUEyd17zOx3RO8jJS0U8vryUWzhny8Cf+nuQ+muR5IqnqlVJIvFFub6HrDD3b+Z7nqCYGZ1k70kzawcuIDoJMRJk9ehQHQ252rgQTPbZma3prugVDOz95tZCHgb8BszeyDdNaVCrAPB5NQqO4CfufsL6a0qtcxsI/AHYK2ZhczsE+muKcXeDnwEOC/2/3ebmW1Id1Epthz4rZltJ/qLz4Pufk8yf4CmuRARkSn53lIQEZFpFAoiIjJFoSAiIlMUCiIiMkWhICIiUxQKIiIyRaEgIiJTFAoi82RmjWZ22Yx9q8zs3th6Di+bWT5Myy45QKEgMn/nA6dMbphZAdH5eG5197XAW4BmM7sqTfWJxE0jmkXmwczeAfwK6AH6gfcDxwKfdPe/mnbecuARdz8mHXWKxEstBZF5cPfHic5Bc4m7n+Tuu4HjgGdnnLcfWBCbnE8kYykUROZvLTB9NbtxoGr6CbEZPSuIrtshkrEUCiLzYGaLgV53H522+3fAhlgQTHoXsMXdJ4KsT2SuFAoi89PEjMV73P1ZYCvwzwBmthT4JvD3gVcnMkcKBZH52QksMbPnzexMADO7DmgGvmRm5wG3AEcC34mtJSySsdT7SEREpqilICIiUxQKIiIyRaEgIiJTFAoiIjJFoSAiIlMUCiIiMkWhICIiU/4/58Lv7APTZIIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "t, s_x = dynamics.expectations(sigma_x, real=True)\n",
+    "t, s_y = dynamics.expectations(sigma_y, real=True)\n",
+    "s_xy = np.sqrt(s_x**2 + s_y**2)\n",
+    "plt.plot(t, s_xy, label=r'$\\Delta = 0.0$')\n",
+    "plt.xlabel(r'$t\\,\\Omega$')\n",
+    "plt.ylabel(r'$<\\sigma_xy>$')\n",
+    "plt.ylim((0.0,1.0))\n",
+    "plt.legend(loc=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Using PT-TEMPO to explore many different laser pulses\n",
+    "If we want to do the same computation for a set of different laser pulses (and thus different time dependent system Hamiltonians), we could repeate the above procedure. However, for a large number of different system Hamiltonians this is impractical. In such cases one may instead use the process tensor approach (PT-TEMPO) wherein the bath influence tensors are computed separately from the rest of the network. This produces an object known as the process tensor which may then be used with many different system Hamiltonians at relatively little cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100.0%   50 of   50 [########################################] 00:00:01\n",
+      "Elapsed time: 1.3s\n"
+     ]
+    }
+   ],
+   "source": [
+    "tempo_parameters = oqupy.TempoParameters(dt=0.1, dkmax=20, epsrel=10**(-4))\n",
+    "\n",
+    "process_tensor = oqupy.pt_tempo_compute(bath=bath,\n",
+    "                                        start_time=-2.0,\n",
+    "                                        end_time=3.0,\n",
+    "                                        parameters=tempo_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given we want to calculate $\\langle\\sigma_{xy}\\rangle(t)$ for 5 different laser pulse detunings, we define a seperate system object for each laser pulse:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deltas = [-10.0, -5.0, 0.0, 5.0, 10.0]\n",
+    "systems = []\n",
+    "for delta in deltas:\n",
+    "    # NOTE: omitting \"delta=delta\" in the parameter definition below\n",
+    "    #       would lead to all systems having the same detuning.\n",
+    "    #       This is a common python pitfall. Check out \n",
+    "    #       https://docs.python-guide.org/writing/gotchas/#late-binding-closures\n",
+    "    #       for more information on this.\n",
+    "    def hamiltonian_t(t, delta=delta): \n",
+    "        return delta/2.0 * sigma_z \\\n",
+    "            + gaussian_shape(t, area = np.pi/2.0, tau = 0.245)/2.0 * sigma_x \n",
+    "    system = oqupy.TimeDependentSystem(hamiltonian_t)\n",
+    "    systems.append(system)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then use the process tensor to compute the dynamics for each laser pulse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "..... done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s_xy_list = []\n",
+    "t_list = []\n",
+    "for system in systems:\n",
+    "    dynamics = oqupy.compute_dynamics(\n",
+    "        process_tensor=process_tensor,\n",
+    "        system=system,\n",
+    "        initial_state=initial_state,\n",
+    "        start_time=-2.0)\n",
+    "    t, s_x = dynamics.expectations(sigma_x, real=True)\n",
+    "    _, s_y = dynamics.expectations(sigma_y, real=True)\n",
+    "    s_xy = np.sqrt(s_x**2 + s_y**2)\n",
+    "    s_xy_list.append(s_xy)\n",
+    "    t_list.append(t)\n",
+    "    print(\".\", end=\"\", flush=True)\n",
+    "print(\" done.\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and plot $\\langle\\sigma_{xy}\\rangle(t)$ for each:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f530c7e8588>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA+G0lEQVR4nO3deXxcdb34/9f7zJLJ2uxJk7RJutCdtUALtCoCQlUQFGSRgsAFvoJ61ety9XsV9d7r+vPqV1FkEVGxXESBAgVZLEvZSkHoku5L2jRpJ02zTyaZ5fP740zSSZrSpJ01eT8fj+Gsc857Sjvv+ZzzOZ+3GGNQSimlAKxkB6CUUip1aFJQSik1QJOCUkqpAZoUlFJKDdCkoJRSaoAmBaWUUgMSkhRE5Hci4hWR9UfYLiLy/0Rkm4isFZFTExGXUkqpwRLVUvg9cOH7bL8ImB553Qz8JgExKaWUGiIhScEY8zJw8H12uQT4g7G9AeSLyMRExKaUUuoQZ7IDiKgE9kQtN0TWNQ3dUURuxm5NkJ2dfdrMmTMTEqBSSo0Vb7/99gFjTMlw21IlKcgw64Ydf8MYczdwN8D8+fPNmjVr4hmXUkqNOSJSf6RtqdL7qAGYFLVcBTQmKRallBq3UiUpLAeWRnohLQDajTGHXTpSSikVXwm5fCQiy4APAsUi0gB8B3ABGGPuAlYAS4BtgA/4bCLiUkopNVhCkoIx5qqjbDfAbbE4VyAQoKGhAb/fH4vDjUsej4eqqipcLleyQ1FKJViq3GiOmYaGBnJzc6mpqUFkuPvX6v0YY2hpaaGhoYHa2tpkh6OUSrBUuacQM36/n6KiIk0Ix0hEKCoq0paWUuPUmEsKgCaE46R/fkqNX2MyKSillDo2mhSUUkoN0KSglFJqgCaFOHr00UcRETZt2hSzY95www2UlpYyd+7cw7Y988wzzJgxg2nTpvHDH/5w2PePZJ/xasOBDdz87M18aeWXuOO1O/j52z/n9+t/z6NbH+WNpjcIm3CyQ1Qq7sZcl9RUsmzZMubPn89DDz3EHXfcEZNjXn/99dx+++0sXbp00PpQKMRtt93Gc889R1VVFaeffjoXX3wxs2fPHtU+49kv//lL3mt+j4nZE2nrbaO9t52gCQ5sP7P8TO446w6qcquSGKVS8aUthTjp6uripZde4r777mPZsmUxO+7ixYspLCw8bP3q1auZNm0aU6ZMwe12c+WVV/L444+Pep/xamvrVl5tfJUb593IY594jBc//SLvXPsOr1/1Ok9f9jT/seA/WN+ynsuWX8ayTcu01aDGrDHdUvjuExuoa+yI6TFnV+TxnY/POep+jz32GOeddx4nnngi2dnZvPPOO5x66qGCcosWLaKzs/Ow9/30pz/lvPPOG3Vce/fuZdKkQ2MKVlVV8eabb456n/HqD3V/wOPwcMUJVwysExFy3DnkuHO4YsYVLKpcxHdf/y7//eZ/8+yuZ/neWd9jUt6k9zmqUulnTCeFZFq2bBk333wzAFdccQXLli0blBReeeWVmJ7PHilksKHPG4xkn/HoQM8BntrxFJdNv4x8T/4R95uYM5HfnPcbHtv2GD9+68d88olP8sVTv8hVM6/CEm10q7FhTCeFkfyij4eWlhZWr17N3/72NwA+/elP84EPfIAf//jHA1/CI20p3Hnnndxzzz0ArFixgoqKimHPWVVVxZ49h+oUNTQ0HLbvSPYZj/688c8Ew0GWzl561H1FhEunX8rCioV87/Xv8cPVP+Qfu//Bf579n0zM0WKBagwwxqTt67TTTjND1dXVHbYu0e666y6zdOnSQetOP/108/LLL8fk+Dt37jRz5swZtC4QCJja2lqzY8cO09vba0488USzfv36Ue/TLxX+HBOhu6/bnL3sbPOFF74w6veGw2Hz1y1/NWf86Qyz4MEFZvm25SYcDschSqViC1hjjvC9qm3eOFi2bBlPPPEENTU1A6+NGzfy5z//+biPfdVVV7Fw4UI2b95MVVUV9913HwBOp5Nf/epXfOQjH2HWrFlcccUVzJljt5SWLFlCY2Pj++4zXi3fvpz23naum3PdqN8rIlw2/TIeufgRTig4gW+u+iZfeekrtPpb4xCpUokhZpjrzOliuHKcGzduZNasWUmKaOwYD3+OoXCIix+7mAkZE3hwyYPHdX8lFA7xQN0D/PKfvyQ/I5/vnfU9FlUtimG0SsWOiLxtjJk/3DZtKahx68U9L7K7czdL5yw97hvuDsvBDXNv4KGPPkSBp4DPvfA5vvby19jXvS82wSqVIJoU1Lj1QN0DVGRXcN7k0XcBPpIZhTN46KMPccuJt/BC/Qtc/NjF/Pa93+IP6lDkKj1oUlDj0trmtfzT+08+M/szOK3YdsJzO9zcfsrtLL90OedUnsOv3v0Vn3j8EzxX/9yw3YKVSiWaFNS49MCGB8h15XLZ9Mvido7KnEp+9sGfce8F95LpzOTLL36Zm569iXf2v6PJQaUsTQpq3GnobOD53c/zqRmfItuVHffznTnxTP7y8b/wzTO/yebWzVz3zHVc+dSVLN++nL5QX9zPr9RoaFJQ484TO57AGMPVM69O2DmdlpOrZl7Fs598lv9Y8B/4g36+tepbXPDIBfz63V9zoOdAwmJR6v2M6SealRrO9rbtVOZUUp5dnvBzZ7myuGLGFVx+wuW83vQ6D258kN+89xvuWXcPCyYu4OyKszmr8ixq82p1CBKVFJoU1LhT31FPzYSapMYgIpxVcRZnVZxFfUc9D29+mJcbXuZHb/0I3oKJ2RMHtp9YciKlWaUpP75SKBwiZEIEw0HCJkzIhAamxhgMZmAaTRBEZNDUEguH5cAhDns+aqrJMr40KcTRo48+ymWXXcbGjRuZOXNmTI5ZU1NDbm4uDocDp9PJ0If3+j3zzDN88YtfJBQKcdNNN/GNb3wjJudPd2ETpr6jnvllwz63kxTVedV89fSv8tXTv8rerr28uvdVXmt8jWd2PcNft/4VAI/Dw6S8SdTk1TA5dzLVedWUZJWQ5cwi25VNljOLTFcm2a5snJbT/jKOfEn3fzEHQgH8IT/+oJ+eYA/+kJ+eQA89QfvlC/rwBXyDpv6gn95Qr/2eUA+9wV78IT99oT77Fe4jEArQF+5L6HDi/cmhP1n0v4YmEaflHFh2iAPLsued4sTtcONyuHBbbtwON27LXu5PSpZYiAgWkWlUUoqeOsSBw7KP2Z/InJYTpzhxOVw4LScu69C0/zxuh3tg2e1wD0qM/ecE+9Jj/74uyxX3xKhJIY7iUWQHYOXKlRQXFx9xuxbTOTKvz0tPsIeavJpkhzKsypxKrphxBVfMuIJAOMD6A+vZ2rqV+o566jvq2dq6lZW7Vw4q/hNrbstNlisLj9NDpjMTj8Oe5rhyKPIU4XF4DvtCdVku+wsw6osx+su5v5Uz8MUX+fLrbzn0JxRjDGHChE142MRmjBlYDpuwvW94cKukf9twLZZQ2J4PmACBUIDeYC+d4U76Qn0Ewva6/niGxjLcuujzJYoguB1urptzHZ8/5fMxP74mhTjpL7Lz3HPPcfnll8c0KRxNdDEdYKCYjiYF2NWxCyDpl49GwmW5OKX0FE4pPWXQ+mA4SFNXEy3+FnxBHz2BHrqD3QO/7gOhwLBfzE7LSaYzc+DlcXrsL35HJlmuLLJcWWQ6M3FZriR94vTVn8CCJmhPw0GCJkgwHCQQCtgJJxwgGA7SF+4b3NKKJKOwCQ9cYus/psHYx4i8fyB5hQOcVHJSXD7L2E4KT38D9q2L7THL58FFR69tHK8iOyLCBRdcgIhwyy23DNRsiKbFdI5sV/suwL5kk66clpNJeZO0wE8KscTCcli4SP+EOraTQhLFq8jOq6++SkVFBV6vl/PPP5+ZM2eyePHiQfsM92CU3pyz1XfUk+nMpCyrLNmhKJWSxnZSGMEv+nhIRJGd0tJSLr30UlavXn1YUtBiOke2s2MnNXk1miSVOoKxnRSS5JFHHmHJkiVkZGQAUFtbS3l5OatWrWLRIns45ZG2FG677TZuu+02ALq7u+ns7CQ3N5fu7m6effZZvv3tbx/2ntNPP52tW7eyc+dOKisreeihh2JSy2EsqG+vZ27x3GSHoVTK0qQQB8uWLWPt2rXU1NQMrGtpaeHPf/7zQFI4Fvv37+fSSy8FIBgMcvXVV3PhhRcObF+yZAn33nsvFRUVA8V0QqEQN9xww7gvpgPQF+qjsbuRj039WLJDUSplaVKIgxdffDEux50yZQrvvffeEbevWLFiYH7JkiUsWbIkLnGkqz2dewib8JFvMm98El74Hpz7LZh9SWKDUypFpPYjkkrFUH/Po9q82sM39rTCk/8KB7fDw0vh4eugqzmh8SmVCjQpqHFjZ8dO4AjdUV/4PqH2g7TXfhf/9M9hNq6AO8+AdY+ADnOtxhG9fKTGjfqOeoozi8lx5wze0PA2rPkd3oYFtD1yJwDiriCjyJC56st4Zt1D5rXfJ2PeGUmIWqnESlhLQUQuFJHNIrJNRA4biEdEJojIEyLynohsEJHPJio2NT7sat91+PAWoSA8+a/4A+W0rd7DhE99koqf/pSCq6/GqjqJ9t35NC3fzY7Lr6Pp375AqKsrKbErlSgJaSmIiAO4EzgfaADeEpHlxpi6qN1uA+qMMR8XkRJgs4g8aIzRKiQqJuo76jl38rmDV751L+xbi3fHB7Gymyj9yldwFhQw4WMfBcCEw/S9+xLtP7iZlqeeo2vNOir++7/IPuusJHwCpeIvUS2FM4BtxpgdkS/5h4Ch3TsMkCv2U0U5wEEgfqN+qXGlvbed1t5WaidE3WTuaIJ//Cfd1gK6/7mF4ltvxVlQMOh9YllknPohSv/rTmrOa8YKd7H7hhtpuuMOQl3dCf4USsVfopJCJbAnarkhsi7ar4BZQCOwDviiMYcPPSgiN4vIGhFZ09ysvUPUyOxst28yD7p89Pd/xwT62L/agauykoLPXHPkA5xwAZkf/RdqF2+h8BMfpO1/H2bnJZfQ/YaOKaXGlkQlheHGFBjapeMjwLtABXAy8CsRyTvsTcbcbYyZb4yZX1JSEus41RhV31EPRPU82vYCbHiU9oxL6N22k5IvfQkr8gT6EZ13B1bVPMoKnqH67l+A08Hu66+n4QtfpHfbtjh/AqUSI1FJoQGIHtKxCrtFEO2zwN+MbRuwE4hNZZokefTRRxERNm3adFzHeeaZZ5gxYwbTpk3jhz8cfjynkewznu3q2IVTnFTmVkKgB576CuG8qTQ/vQXPvHnkLbno6AdxZsCn7oegn6ztv2DK3/5K8ec+R/eqVez4+MXs/drX6Nu9O/4fRqk4SlRSeAuYLiK1IuIGrgSWD9lnN/BhABEpA2YAOxIUX1xEF9k5Vv0Fc55++mnq6upYtmwZdXV1o95nvKvvqKcqt8quFfD2A9C6k4O95xPc76Xsa19FrBH+UyieDkt+ArtewXrnt5R84fNMfeF5im68gc5nn2P7RUto+o9vE2gc+ptHqfSQkKRgjAkCtwN/BzYCDxtjNojIrSJya2S37wNnicg64AXg68aYA4mILx76i+zcd999LFu27JiPE10wx+12DxTMGe0+493O9p2H7ifseZOgexItf3menPM+TNbpp4/uYCdfA3M/Cf/4L9jzFs6CAkr/7d+Y+uzfKbjqKtofe4ztH7mQvV/+Ml0vvYQJan8JlT4S9vCaMWYFsGLIurui5huBC2J5zh+t/hGbDh7fpZuhZhbO5OtnfP2o+8WqyM5ICuZoUZ33FwqH2N2xm3Mqz7FX7F9Pc10B4d5WSr/8ldEfUAQ+9j/Q8Bb89Qa45RXIzMdVWkr5//0WRTd8lpbf3U/Hk0/SseJpHCXFTPjYx5nwiUvwzJgR2w+nVIzpE81xEqsiOyMpmKNFdd7fPt8++sJ99k3mQA+9O3fS9k4pBVdeRcaUYcZBGgnPBPjk7+D+C+Gxz8Gn/wSRS1CuigrK/++3KPvaV+l86SXaH3+cg3/8Iwfvv5+MWbPI+8hHyP3wubinTdP/TyrljOmkMJJf9PEQyyI7IymYo0V13l//QHg1eTXQvIm27ZmIZVF8+23Hd+BJp8MF/wnPfANe+wWc86VBm8XtJu/888k7/3yCra10PLWC9uXLaf75z2n++c9xTZ5M7rnnknPuh8g69VTEOab/Oao0oX8L4yCWRXZGUjBHi+q8v10duwComVADG5+mt9VJxtQanIWFx3/wM2+FPavtIbcrT4PaxcPu5iwooPAz11D4mWsI7N9P18qVdL7wD1offJCDv/89jvx8ss86i6yFC8heuBB3VdXxx6bUMdCkEAexLLLjdDqPWDBHi+qMzK72XeS4cijyFGH2rcff5ibnrHmxObgIXPxL2L8BHrkBbnkZ8t6/leYqK6PgyispuPJKQl3ddK96hc5//IPu11+nI1ITw1VVRfbCBWQtWEDWaafhLCvTS00qIWS469HpYv78+WbNmjWD1m3cuJFZs2YlKaKxYyz9Od787M109nWy7GPLCPzqQrb9qp6yb/47hUuXxu4kzZvh7g9B+Vy47klwukd9CGMMfdu30/3Gm3S/8Tq+1W8R7ugAwFFSTOa8E8mcNxfP3HlkzpuLIz8/dvGrcUVE3jbGzB9um7YU1Ji3q2MXp5adCsbQu3kLkEHGjBg/F1kyAy75pd1aeO7bcNHoHyAUETKmTSNj2jQKP3MNJhTCX7eRnvfew79uHT3r1tH1j38M7O+cOJGM2hrcNbW4p0zBXVtDRm0tzvLykT93odQQmhTUmNYT7KGpu8m+ydzZhN/bC2TgmRmHrqFzPwl73oI3f2PfhJ77yeM6nDgcZM6bS+a8uQPrQp2d+DdsoGfdOnq3bqVv5y7aH3+ccHfU4HwuF66SEpxlZTjLynCVleIsLcNZUoyVl4cjbwKO/Ak48vJw5OUh7tG3atTYpUlBjWm7O+xhJ2ryamD/BnpbnThLCnFMmBCfE17wfWj8Jzz+eSg+AcpjdO8iwpGbS/aCBWQvWDCwzhhDsLmZvp276Nu5g8DevQT27ye430vvpk10vfwyxuc74jHF48HyeJDMTKzMzEPzGRmI2424XIdebnuK5UAcFjickakDsRzgsOxWiuUAS+x1loVYErXOArEOzfcfy7Jf4nCAWIjTcWh5YB+HfSyHA0QO7TsQw+DpwLaBeO1t4nTan8Pl0ns1Q2hSUGPaoJ5HdU/jb3PhOTmO90ocLrj8frjnw/DAxXDdE/Z9hjgSEVylpbhKS8k+8/DqcMYYwl1dBA8cINzRQaijg1BbO6GO9shyJ6bXT7jHT9jfg/H1EPb7CXV3QVsQEwgMfvX1YcJhCIUwoZA9jSyno+ikN5AkLMvuRGAJIv0JKzLviCQmiUpATgficEbmnXaycjoQp8tOQJEXLueQJBtJuk5X5JgCRKYi9mz/MVwuJPJ+nE4yamvJmDYt5n8emhTUmNY/Ourk3MmE96ylr9NF7uz4fkmTVwHXPwkPfNx+Xbc85i2G0RARHLm5OHJz43oeY4xdzzoUsudDIQiH7YTRPzVm0LpB2/v3D4UOHWdI0jFhA+HQ4PeHwva6YadhTDgEoUNTwiFMMJLs+oYku2AQjMGYMITN4fGacCSGIccNhg5NAwHCPT57PhiMvAIQCB46b9Q5j7UGeNG/3ETpV47hifyj0KSgxrRd7bsoyyojy5VFz6b1YMAzMwGD7xZNtVsJD3w80mJIbmJIBOn/dWtZw46Vr4ZnQnYiIZI07RwRSUjG2Nv7AhCMSibBII4hBaFiRZOCGtN2deyyLx0Fe+nduReYQEaixh8qmmq3GH7/sUiL4YkxnxjU6InDYV9uShHab02NWcYYOylEhrfwtzkQjxv35MmJC6Jwip0YXNl2Ymham7hzK3UMNCnEUayK7NTU1DBv3jxOPvlk5s8f9nkTLbIzjIP+g3T2dUb1PHLhmVqb+F9l0YnhDxdD/euJPb9So6BJIY5iUWSn38qVK3n33XcZ+gQ3aJGdI+m/yVwzocYe3qLdRcacE5MTTGGtnRg8+fD7JfDcdyDYm5xYlHofmhTiJFZFdkZCi+wMr787anVeNcGt7xLus/Akc+iOwlq49RU45Vp49ef2sBj71iUvHqWGMaZvNO/77/+md2Nsi+xkzJpJ+Te/edT9YlVkB+xeHRdccAEiwi233DJQp6GfFtkZ3q6OXbgsFxVZE/Ft3gK4Yj+8xWhl5MLF/w9mfhQev91ODB/6Jpz9RfvhrnRhDPjbobvZfnV5wXcAejujXl3Q2wF9XXarqP8V6oVgnz0NB8Ec6u6JCdlTwO6kb0X13bewuzUN7c9vDfOKXm8//HZo3gLLCZbLfq7E4Y68IusGnS96PnL+Yc8XdQ7LETm+M2redWi5/5wD53dFzmsNfGz6+2+JDI7Vch7aP6sIsoti/r92TCeFZIpVkR2AV199lYqKCrxeL+effz4zZ85k8eJDQzRrkZ3hNXU1MTF7Ig5fC737ewAXGSeckOywbCd8BD73Bjz1JXjhu7DlGbjwB1BxauSLKMlCAWjbDW31keluaNtjT9sb7EQQOsLlL3FARg5k5NlJ0J0NTg9kRaYOd2Qa9UXZ/8Xa/2UORHfLtOfDUfNRUxOO2h4+tC4cGpxoBpbD9ucLB+xpoAdCfYfWDXvsI5wr+pjhkH2ucMhOdsR5sNGz/xXO/27MDzumk8JIftHHQyyL7AADBXNKS0u59NJLWb169aCkoEV2huf1eSnNKoX96/G3uXBNLMGRk53ssA7JLoLLH4B1j8CKr8A950LZPDh1KZx4OWTGpx/6ID1tcGArHNgSeUXmW3dGvtgixAETKiG/GmoXQU4pZJdAdinkRKbZxXYicGWmRmJLtnDY/jMc+goF7CQ0dH5QwuPQfDgYSWDBQ4ksHLSHUYmDMZ0UkiWWRXa6u7sJh8Pk5ubS3d3Ns88+y7e//e1B+2iRneE19zQzt3iunRRaXXjOmJ3skA4nYieA6efD+kfgnT/A01+FZ/8vzL7EThDVZw+U+jwmxtiXdw5uh+ZN9jDf/dPOpkP7WS772YrSmTDr41A0DQqqIX8y5FbYl1fUyFkWWG4gvQYc1P/LcRDLIjv79+/n0ksvBSAYDHL11Vdz4YUXAlpk5/0YY+yWQmYp4W1rCXQ5mTAnhR8cy8yH02+yX43vwj//CGv/Auseti+1FNTaX9iFUyLTqfalmaDffgX8h+a7D9iXfVp3QWvk8k+w59C5XNn2UN9TPmRPi0+wp/nV+sWvNCnEw4svvhizY02ZMoX33ntv2G0rIlW6wE4QS5Ysidl5011HXwe9oV5Ks0rxb3wYSNDwFrFQcbL9Ov/7sOkpaHoXDu6wL+1sfda+3HA0GXn2r/zi6XYrJL/a7v1UMhPyKo+v5aHGNE0Kakxq9jUDUJpRSO/ORiA3+T2PRsudZV9aOvHyQ+vCIejYCy3b7Rukzgy7JeHy2FOnx74XkVmg1/XVMdGkoMYkr88LQEnAj7/Vwsry4KocAzffLYd9jT8/gUN1qHFF25BqTPL22EmhtPMAva0uMqZN0W66So2AJgU1JvVfPipuqcff7sIz96QkR6RUetCkoMYkr89LnjsPx5a1mKCQkczhLZRKI5oU1JjU/+Caf8tWII16HimVZJoU1JjU3NNMqTuf3n0+ECFj+vRkh6RUWtCkoMYkr89LiTjwtzlxV5VheTzJDkmptKBJIY5iVWTnhhtuoLS0lLlzBxecH2lhnfFWgCcUDnGg5wClfX12YZ3Z4/vpbqVGQ5NCHMWqyM7111/PM888M2jdSAvrjMcCPK29rYRMiPLWNgI+JxlztOeRUiOlSSFOYllkZ/HixRQWFg5aN9LCOuOxAE//g2sTd7cB4Jk5I4nRKJVexvQTza88vIUDe7piesziSTksuuLoQ9bGssjOcEZaWGc8FuDpTwqFe9oA0m94C6WSKGFJQUQuBH4BOIB7jTGHXdwWkQ8CPwdcwAFjzAcSFV+sxbLIznBGWlhnPBbg6U8Kmfu6CGbl4iwtSXJESqWPhCQFEXEAdwLnAw3AWyKy3BhTF7VPPvBr4EJjzG4RKT3e847kF308xLrIznBGWlhnPBbgae5pxsLC0WGQsvwxnwSViqVEtRTOALYZY3YAiMhDwCVA9B3Pq4G/GWN2AxhjvAmKLeZiWWTnSEZaWGc8FuDx+rwUufMIdneTUVuW7HCUSiuJutFcCeyJWm6IrIt2AlAgIi+KyNsisnS4A4nIzSKyRkTWNDc3xync47Ns2TKeeOIJampqBl4bN2485i/jq666ioULF7J582aqqqq47777cDqdA4V1Zs2axRVXXDFQWGfJkiU0NjYCvO9+Y5XX56XEkUXA58BVNenob1BKDUhUS2G49vvQi91O4DTgw0Am8LqIvGGM2TLoTcbcDdwNMH/+/DhXxj42sSyyAxyx99KRCutEF995v/3GqmZfM1N8FiZk4arWJ5mVGo1EtRQagOifbFVA4zD7PGOM6TbGHABeBrSDuRo1r8/LpNYAAK6aaUmORqn0kqik8BYwXURqRcQNXAksH7LP48AiEXGKSBZwJrAxQfGpMaIv1EdrbysTD9g1iV2VQ69SKqXeT0IuHxljgiJyO/B37C6pvzPGbBCRWyPb7zLGbBSRZ4C1QBi72+r6Yzyf9jg5DsN1Y00XB3oOAFB8wAeAa4z3tFIq1kaVFERkPrDWGDOCyuGDGWNWACuGrLtryPJPgJ+M9tjRPB4PLS0tFBUVaWI4BsYYWlpa8KTpAHL9zyjkHezBynBi5eUlOSKl0suIk4KITAReA24A/hS3iI5TVVUVDQ0NpGrPpHTg8XioqqpKdhjHZODBtdY+XEUF+sNAqVEaTUvhOuAB4CZSOCm4XC5qa2uTHYZKkuYe+8eAs8vCVatPMis1WqO50Xwt8O+AW0SmxikepY6L1+fFJU7C3Q69yazUMRhRUhCRDwGbIl1F7wdujGtUSh0jr8/LpFAm4YCFa7K2GJUarZG2FG4E7ovM/y9wuYjosNsq5TT7mpnaYf/VdNXq6KhKjdZRv9gjA9UtAJ4GMMZ0AG8A4+cRWZU2vD1eJreGAHBNmpzkaJRKP0e90WyMaQOmDVl3bbwCUup4eH1eJh60n2Z26jMKSo3amC6yo8aX7kA33YFuilrCiENwFhcnOySl0s5IbzQ/LyI6DpFKac0+uztqXmsfzsIsxNLbXkqN1kj/1XwN+B8RuT/yEJtSKaf/wbWsDoO7tCjJ0SiVnkaUFIwx7xhjzgWeBJ4Rke+ISGZ8Q1NqdLw9dlJwdFk4J5YnORql0tOI29dijxewGfgN8Hlgq4joDWeVMpp9zbiCBvwOXJOqkx2OUmlppPcUVgF7gf/Brph2PfBB4AwRuTtewSk1Gl6fl0mddt8JV+2MJEejVHoaae+jW4EN5vAxlT8vIlrzQKUEr8/L1A4HwPtWXFvX0M7zG/fzr+dN1wHzlBpiREkhuq6BiDiMMaGozR+NeVRKHYPmnmZObbN/txxp3KNgKMxX/vIuW/Z3sWBKEQun6g1ppaIdS5+9uyOV0RCRxcaYHTGOSalj4vV5mdgaAAFXWemw+zzydgNb9nfhcgj3rdK/ukoNdSxJ4dvAfSLyR+D0GMej1DExxtDsa6aoNYBzggdxuQ7bp7s3yM+e28Kpk/O59QNTeWGTlx3NXUmIVqnUdSxJ4fvYvZAM8HBsw1Hq2LT3ttMX7iOvPYSreMKw+9zzyg68nb1866OzuXZhNS7L4v5XdyU2UKVS3Eh7H30navFrxpg7gP8DfGf4dyiVWP3PKGR2Cq7ywy8deTv8/PalHXx03kROqy6gNNfDxSdX8MjbDbT5Rl1dVqkxa6Qthe+IyI9E5B7sYbMLjDHdwC1xjE2pEfP6vFhhg6PbwlU16bDtP3tuC8FwmK9deKir6o3n1NITCPHn1bsTGapSKW2kScEAfuDvwCTgNRE5aUgvJKWSptnXTEEniBFc1YMLA27a18HDa/Zw7YIaqouy2fFuM8/fX8eMslzOnlbEH16rJxAKJylypVLLSJPCJmPMd4wxjxhjvglcgv0gm1IpwevzUtJhz7umzBq07QcrNpGT4eTz506j40APz/++js1v7mP3hhZuOmcK+zr8rFjXlISolUo9I00KB0TktP4FY8wWQKuiq5Th9Xmp6a+4FjXExStbm3lpSzOfP3c6+ZkuXnjAftYyM9fFhpf38oETSphSks29r+zk8GczlRp/RpoUvgD8SUT+JCJfF5EHgZ1xjEupUfH2eJnUZs+7JtoD+YbChv96aiNVBZksPaua9/6xh8atbSy6YjpzFlWya30LXa1+bjynlnV723lrV2vyPoBSKWKko6S+B5wMLIusWglcFaeYlBq1Zl8z5W1BHNlOrEx7AN/H/rmXTfs6+fqFM+ny9vDGYzuoPamYmQsnMvucCgTY+GoTl51SRX6Wi3tf0YfZlBrxcwrGmF5jzFPGmB8ZY+6N9D5SKiV4fV6K20K4inIH1j1bt49JhZlcNLuM5++vw53p4IPXzEREyC30UD23iLpVjbgdwmfOrOa5jfupb9G/1mp809JUKu0Fw0FaelrI6wBXVHGduqYOTqzKZ81Tuziwp4sPXjOTrDz3wPY5iyvxdfSx670DLF1YjdMSfZhNjXuaFFTaO+g/SNiE7AfXKuyB8Np7Auw52MNsVwbv/L2emWdNZMrJg/tGTJ5TRE5hButf3ktpnoePn1TBw2v20N0bTMbHUColHDUpiEjW0PrMIjJZRIYfhlKpBPP6vOT5wAoJrupaADY1deAy4H67lZxCD4suP3wobcsS5pxTScOmVtr2+/jkqVX4+kK8saMl0R9BqZQxkpZCAPibiGRHrbsX0FrNKiV4fV5K2u15V+1MwL50dIbfSV97Hx++bhbuzOFHiZ919kQsS9iwqpHTqgvwuCxe2XogUaErlXKOmhSMMQHgUeDTYLcSgBJjzJo4x6bUiDT7minuiNRRqLFbBHWNHUwxTspq86g8oeCI782ekEHtycVseq0JJ3BGbRGvbG1ORNhKpaSR3lO4F/hsZH4pcH98wlFq9Lw9Xsr6WwqR4jp1je2UBIXS6ryjvn/O4kr83QG2v9PM4unFbG/uprGtJ54hK5WyRvqcwiYAETkB+/mEP8YzKKVGw+vzUtUOltvCysujLxjmQKMPRxhKJ+ce9f1VJxQwoTSTDa/s5ZzpxQCs0ktIapwaTe+j+7BbDGuNMfrop0oZ+7r3MbEtjKswCxFhe3MXRQF7W8kIkoJYwpxFlTRta6c4KJTkZvDKNk0KanwaTVJ4GDgJOzkolTKauvZS3B7GVWLfO6hr7KAsZOFwWRSUZ43oGDMXluNwWtStamLRtGJe3XaAcFjHQlLjz2ieaPYZYyYYY54/lhOJyIUisllEtonIN95nv9NFJCQinzqW86jxJWzCNHXvI69DcE0sB+yeRxUhi+JJOViOkf0Vz8xxM/W0Eja/0cTZtYUc7O6jrqkjnqErlZIS8vCaiDiAO4GLgNnAVSIy+wj7/Qi7boNSR3XQfxBHTx+uPsE1aTIAdXvbKQ1blI3gJnO0GWeW0+cPMc3Y9Z21a6oajxL1RPMZwDZjzA5jTB/wEHZNhqE+D/wV8CYoLpXmGrsaKe7veVRzAsYYGvd04gxDSfXR7ydEq5iej9Nt0b6zk5nluazapl1T1fiTqKRQCeyJWm6IrBsQeUL6UuCu9zuQiNwsImtEZE1zs/6jHe8auxspaY88ozB1No3tfrJ9dhW10smjayk4XQ6qZhRQv/4A50wt4q1drfT0aXFBNb4kKinIMOuG3sX7OfD1o5X4NMbcbYyZb4yZX1KidX7Gu6aupoGKa86qydQ1dlAetLBcFvkjvMkcrXpuER0H/JxebHdtXb3rYIwjViq1JSopNGDXdu5XBTQO2Wc+8JCI7AI+BfxaRD6RkOhU2mrsaqSiHcQBzuLiSM8jsW8yW8P9Fnl/k+fYo6wWdYRxOyxW6dPNapwZfkCY2HsLmC4itcBe4Erg6ugdjDG1/fMi8nvgSWPMYwmKT6Wppu4mFrcZnPmZiGVR19jG7LCD8prRXTrql1ecSUF5Fo2bDjK/pkBvNqtxJyEtBWNMELgdu1fRRuBhY8wGEblVRG5NRAxqbGrs2ktZawh3mf2MQsPuTpxmZE8yH0n13CL2bm3jnNoiNu3rxNvpj1W4SqW8RLUUMMasAFYMWTfsTWVjzPWJiEmlv6auRvLbBddJFXT4A3CwD3BTMsruqNEmzy3i3ef3MMdhF+R5ddsBLj2lKkYRK5XatMiOSlsdfR2Yzm7cvYK7diqbmjopC1qIyyK/bPQ3mftVTM3HleHANPZQmO3WS0hqXNGkoNJWU1cT5ZFRuNzT51LX2E55SCiqOrabzP0cLouqmQXs2XCQs6cWsWrrAYzRIS/U+KBJQaWtxq5GytoizyicMI+6ve2UhS0qao/90lG/6rlFdB70s7A4D29nL1v2dx33MZVKB5oUVNpq7G6krL+lMGkSu+s7cJqR1VA4mv6uqZV+u8WhhXfUeKFJQaWtpq4mKloNjhwnoQwPPfvswjiloxzeYji5hR4KK7Jp3d7B1JJsva+gxg1NCiptNXY3MqnV4C7JY3tzF8UBQVxCfumx32SOVj23iKZtbSyuLeLNnS30BnXICzX2aVJQaaupYw8lbQZ3Rak9vEXIIr8iBzmOm8zRqucUEQ4ZTsnIxB8I81zd/pgcV6lUpklBpS1v215yusA1uYa6hnZKQ8KkqRNidvzyaRNweRzkHAxQU5TFPa/s1F5IaszTpKDSkj/ox9XcgSC4p85k1852nAhlxzi8xXAcDotJswrZU3eQG86u4b09bayp10q0amzTpKDSUlN3E2Wtke6oM06io6kbGFlN5tGonltEV2svH64oJD/LxT0v74jp8ZVKNZoUVFpq6mqirM2eP1g8mTyfgRjeZO43ebbdNXX/5jY+c2Y1z23cz84D3TE9h1KpRJOCSkuN3Y2UtxpwC5t8FmUhi9yJ2TG7ydwvpyCDoqoc6te3sPSsalyWxe9W7YzpOZRKJZoUVFpq7GqkvM2QUZRFXWMHpSFh8tT8uJyrem4R+7a3k2c5uOTkCv7y9h5au/vici6lkk2TgkpLTZ0NVLSCu6yIHdvbcCJUTIndTeZo0+eXYYzhjce2c9OiKfgDYR58sz4u51Iq2TQpqLTU1LaLonaDa1Il7Y32Nf7R1mQeqeKqHE46bzIbXmkkuz3I4hNKeOD1en2YTY1JmhRUWupp2oszJEj1VJztAYxTmFCSGbfznfHxWiaUZLLyjxu5cUE1zZ29LH93aEVZpdKfJgWVdoLhIA5vOwDNJdMpDVpklmbG/CZzNJfbwblLZ9JxwI+1vp2Z5bnct0ofZlNjjyYFlXa8Pi8lkWcUNmVPpjgkTIzhQ2tHUjG9gLkfqGTtygaWnjCRTfs6daA8NeZoUlBpp7+OgrFgY3sGboSaOPU8GmrhpVPJKcjAvNlCeU4G97yiD7OpsUWTgko7Td12xTUr38X+hsiTzJNi+yTzkbg9Tj70mZm07fdxbW4+r2w9wN837EvIuZVKBE0KKu00djVS2mbIKJmAv9mPESicmJ2w80+eXcTMsyYimzs4uyiXW//0Nne9tF3vL6gxQZOCSjtN7TspbwVHeRm5foM1wYXDldi/ymd/chqZuW4+2pPBJyeX8D9PbeLf/rJWu6mqtOdMdgBKjVZL0zaye6GzuJLSgxYFlTkJj8GT7eKD18zk6d+spbYRvkAm3SsP8NM3X+a0eaWUV+XiznTicFo4nBZOl4Uj8srIcpKZ48aT7cRy6O8ylVo0Kai0E2xoAmBXzhRyW4SaGNZQGI3aE4u59r/OomVvF637fKyta2bL1lbqVu9n+xsjK8iTkeXEk+MiM8eFJ8cdNW9PM3PcZGS7yMhy2vtmJb5VpMYXTQoqrRhjcHg7ANhgqskGqqbkJy2e3EIPuYUeaubBKedPZm1DG//yhzUEfEFuWljLJSdOxGNZhIJhgoEwob4wfl8Af1cAf3eAns4A/q4+eroCdB7007y7k56uPsLBI9+fcEZaG+5MJy6PE7fHgSvDgdvjxOVx4HI7cLotnG4HDpeFKzJ1uqyBlovDJVgOe95yCg6HheUQLIcg1qFlcQiW2FMREInfsyAqNWhSUGmlxd9CYWsYgIbuHGZgD0ORKk6syufx287ha39dy49f2cZv3trFdQtr+OzZNZTmZIzoGMYYAr0h/F2RpOEL0OsL0OcL4vcF6fUF7eWeIAF/iD5/iJ7OPgK99nygN0QoEI7L5xNLEAs7UViRRGENmZdDCUQsIHp5YJ/D1x9ajiSfI2xDBAH6/yNW/2xkX6LfF9knMh+930DMUcuDj31o//4FGZhGrYuKSawh5xv6mfvjFRn48zn0WQf9SR+aGxJr/75FlTmUVsf++RxNCiqtNHU1Ud5mCGVbhDsNYY9FZo472WENUj7Bwx9uOIO1DW38euV27nxxG/eu2sGVp0/mXxZPoTL//YfjEBHcHiduj5O84mMbusOEDcGg3TIJ9NlJIhgIEQoaQsEwoWCYcPR8yEReYUzY4O8L0ekL4OsN4u8L0dMXwt8XorcvhL8vTDBkv0KhMMGgIRgyhMNhwsZgwvb5jQHCHOqVNTAFicwOfG9jr4tetrC/fAcvH3ofQ7ZHT6OPgxnufVGvodvN4H2jRW8fbl30Zxm0PQ7yTy3imptPivlxNSmotNLY3WhXXCvMojgoZFbFb7yj43ViVT53XXsa27xd3PXSdv70Rj1/eqOeRdOLuWBOOefNKqMkd2Sth9ESS3C57UtJHlyDtnX4AzQc7KGh1cfe7h4a23rY39GLt9OPt7MXb0cvXb3BIx7b7bDIynCQ6XKQmWVPs9xOPC4HLoeF0xJ76hCclr1sWYIldgvDiroM1f/reGhvXmMMBggbQ9hA2ETWGTD0TxlYZmDZ3r//vfbBot4Tme8/nn3s6GUzKJ5DhxiyfiDQofGYqLgiy+HIcSPnkqhzm0iwR+zO3H+c0KGT9/85XDYpPn93NCmotNLUsYdpbRCaUkxRWCiPQ/M51qaV5vDTy0/iS+efwB9e28WK9U2s/Ns6vinrOHVyARfMLuOCOeXUFsfmWQt/IMTeth52H/TRcNDH7shrTyQRdPgHf+FnOC3K8jyU5mYwqzyPxdMzKM3LoCQng/wsNxMyXeRnuZiQab88LkdM4lSpSZOCSiv79m3izE7YO2EGFsK06QXJDmnEKvMz+fcls/jGRTPZtK+TZzfs59m6ffzg6U384OlN5HmcTCrMYnJhFpMKs5hUkElVYRbZbifBcJhQ2L5MEwwbQuEw7T0B9rX3sr/Tj7fDz74OP/s7ejnQ1Tvol3eG0xo43mnVBVQVZFJVkBWZZlKY7dYbyGqAJgWVVnz12wCod9dCkLRoKQwlIsyamMesiXl88bzp7DnoY+VmL1v3d7H7oI/N+zt5YZOXvuDIbhYXZrspy/NQlpfBnIkTKJ/gobrITi6TC7MozsnAiuMIsmps0aSg0kqw0e7/38hE8i3iWkMhUSYVZrF0Yc2gdeGwwdvZy55WH33BMA5LcFoSmVo4LCEv00lJbgYZTr2co2JHk4JKK87mLgD84QlYBe641lBIJssSyid4KJ/gSXYoapzRRyNV2ujs6yS/NUTADYVhF/mViRsET6nxImFJQUQuFJHNIrJNRL4xzPZrRGRt5PWaiMS+A65Ka3YdBegsLsWDUDM1fW4yK5UuEpIURMQB3AlcBMwGrhKR2UN22wl8wBhzIvB94O5ExKbSR1OX/YxCe+EUAKZOz09uQEqNQYlqKZwBbDPG7DDG9AEPAZdE72CMec0Y0xpZfAOoSlBsKk00tmyhtB1as6dggKKqxBTWUWo8SVRSqAT2RC03RNYdyY3A08NtEJGbRWSNiKxpbm6OYYgq1bXuWIcrBG2uSYSy7ad1lVKxlaikMFwXkWGf6xaRD2Enha8Pt90Yc7cxZr4xZn5JSUkMQ1Sprqd+JwB9jhIyS9O/K6pSqShRXVIbgElRy1VA49CdRORE4F7gImNMS4JiU2ki0OQl4MzELZmUT9ZLR0rFQ6JaCm8B00WkVkTcwJXA8ugdRGQy8DfgWmPMlgTFpdKEL+CDA9105lYAcMKMwiRHpNTYlJCWgjEmKCK3A38HHMDvjDEbROTWyPa7gG8DRcCvI+OwBI0x8xMRn0p9G1o2UNYK7UV2g3PS1PzkBqTUGJWwJ5qNMSuAFUPW3RU1fxNwU6LiUenlvX1vU91saKmuJeAUsvJSq4aCUmOFPtGs0sLmzS9S1QIHM6uxCnVUT6XiRZOCSnnGGPrWbSYsFiFnEQUVOryFUvGiSUGlvIbOBqrqe+nKKcMSi2q9n6BU3GhSUCnvXe8/mbXH0FY5FYCZM4uSHJFSY5cmBZXy6ratpHY/NBfOJCRQrJePlIobTQoq5bW9vRrLQKOrhnCuE8uhf22VihctsqNSmi/gI3d7K31ONx7Jp3T6hGSHpNSYpj+5VEqra6ljxh7D/uq5OBDOPFsHz1UqnjQpqJS2dvtKpjdCY/F8gg6YPEML6ygVT5oUVErbv/ofOENCh2cGnknZOPR+glJxpf/CVMoyxiCb9tKZOwmHeJh7enmyQ1JqzNOkoFLW3q69VO8O0lg1DwOceubEZIek1JinSUGlrPd2r2LGXkNzwUkEC1xk5uggeErFmyYFlbJ2v/YEFhMIuCupmqP1E5RKBE0KKmX1rttMS9EcAM5apF1RlUoETQoqJfmDfgp3+thXNpdetzBxcl6yQ1JqXNCkoFJS3f53mb7XQXveTHJqc7V+glIJoklBpaQtrz5MKGM6xsrg1AXa60ipRNGkoFJS+5q3aCmaS5gwJ5+mzycolSiaFFTKMcaQse0gzSVzCZZ6cLodyQ5JqXFDk4JKOY0dDVQ2l9GbUcyUk0qSHY5S44omBZVy6t78X0KeuQAs+sCkJEej1PiiSUGlHO+rL3CgaC4hl5/C4qxkh6PUuKJFdlRKMcYQ3NxK14QpZM3SYbKVSjRtKaiU8vx7yyg6OB3E4sxz9NKRUommSUGljJ5gD5t+8UP82XMJE2DuXL3JrFSiaVJQKeMvD/8bp20oZ3/pKTimFSCWPsWsVKJpUlApobFtF7n3r2LjrM/S57JYevNJyQ5JqXFJk4JKCU/88HpM5qfo8ZSy+Lo55ORlJDskpcYlTQoq6d56+2GqV0+kqeJssk4q4LTTdawjpZJFk4JKqmA4yMYf/5L62qsJunv0spFSSabPKaikeurez+PgGoJOJ5d8eSFOp45zpFQyaVJQSdPWuofeFW7ayk9g4uICamrykx2SUuOeXj5SSREI9fHYN77EgdKP4cho4NKrTk52SEoptKWgEqy7+yBP/X9fJbA2n768z2BZHXz6u5drZTWlUkTCkoKIXAj8AnAA9xpjfjhku0S2LwF8wPXGmHcSFZ+Kr3316/n7T36JtMyiM+8qKLZwsovTP/sBCvIzkx2eUioiIUlBRBzAncD5QAPwlogsN8bURe12ETA98joT+E1kqlJYOBQi4PfT1+fH19nO7s0b8O7YQee+Fvra/YR8QE8GQesk+jI+jSO7g8zsTXzwc1cyZdq5yQ5fKTVEoloKZwDbjDE7AETkIeASIDopXAL8wRhjgDdEJF9EJhpjmmIdzIPf+g4dXs03R3ekSzqCEcGIBTK0t1A2MG/wKk+YjN4tlE47yCVfvBG3S3sYKZWqEpUUKoE9UcsNHN4KGG6fSmBQUhCRm4GbI4tdIrL5GGMqBg4c43vTVfI/81dvSfQZk/+ZE08/8/hwPJ+5+kgbEpUUhvvJaY5hH4wxdwN3H3dAImuMMfOP9zjpRD/z+KCfeXyI12dOVJfUBiB6cPwqoPEY9lFKKRVHiUoKbwHTRaRWRNzAlcDyIfssB5aKbQHQHo/7CUoppY4sIZePjDFBEbkd+Dt2l9TfGWM2iMitke13ASuwu6Nuw+6S+tk4h3Xcl6DSkH7m8UE/8/gQl88sdmcfpZRSSoe5UEopFUWTglJKqQHjOimIyE9EZJOIrBWRR0UkP9kxxZuIXC4iG0QkLCJjugufiFwoIptFZJuIfCPZ8cSbiPxORLwisj7ZsSSCiEwSkZUisjHyd/qLyY4p3kTEIyKrReS9yGf+bqzPMa6TAvAcMNcYcyKwBfj3JMeTCOuBy4CXkx1IPEUNrXIRMBu4SkRmJzequPs9cGGyg0igIPAVY8wsYAFw2zj4f9wLnGuMOQk4Gbgw0lszZsZ1UjDGPGuMCUYW38B+NmJMM8ZsNMYc61Pg6WRgaBVjTB/QP7TKmGWMeRk4mOw4EsUY09Q/aKYxphPYiD0KwphlbF2RRVfkFdPeQuM6KQxxA/B0soNQMXOkYVPUGCQiNcApwJtJDiXuRMQhIu8CXuA5Y0xMP/OYr6cgIs8D5cNs+pYx5vHIPt/Cboo+mMjY4mUkn3kcGNGwKSr9iUgO8FfgX40xHcmOJ96MMSHg5Mg90EdFZK4xJmb3kcZ8UjDGnPd+20XkOuBjwIfNGHlo42ifeZzQYVPGARFxYSeEB40xf0t2PIlkjGkTkRex7yPFLCmM68tHkcI/XwcuNsb4kh2PiqmRDK2i0likMNd9wEZjzM+SHU8iiEhJfy9JEckEzgM2xfIc4zopAL8CcoHnRORdEbkr2QHFm4hcKiINwELgKRH5e7JjiodIB4L+oVU2Ag8bYzYkN6r4EpFlwOvADBFpEJEbkx1TnJ0NXAucG/n3+66ILEl2UHE2EVgpImuxf/g8Z4x5MpYn0GEulFJKDRjvLQWllFJRNCkopZQaoElBKaXUAE0KSimlBmhSUEopNUCTglJKqQGaFJRSSg3QpKDUMRCRKhH5dNTyb0Xk7GTGpFQsaFJQ6th8GDg1avlM7OHXlUprmhSUGiUROQf4GfCpyNAKs4AtxpiQiNREqvk9EKno94iIZIlItog8FamYtT66laFUKtGkoNQoGWNWYY87c4kx5mTs6m7PRO0yA7g7UtGvA/gc9kiWjcaYk4wxc4fsr1TK0KSg1LGZAfRXsPsIg7/k9xhjXo3M/wk4B1gHnCciPxKRRcaY9sSFqtTIaVJQapREpAhoN8YERCQLyDfGRNdqGDrKpDHGbAFOw04OPxCRbycoXKVGRZOCUqNXy6GCPR8CVg7ZPllEFkbmrwJWiUgF4DPG/An4KYNvUiuVMsZ85TWl4mATUCwi67Hr5H5vyPaNwHUi8ltgK/AbYBHwExEJAwHg/yQwXqVGTOspKHUcROQd4ExjTCCyXAM8GbmZrFTa0ZaCUsfBGKOXgdSYoi0FpZRSA/RGs1JKqQGaFJRSSg3QpKCUUmqAJgWllFIDNCkopZQaoElBKaXUAE0KSimlBvz/5lUgkGTOWEoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for t, s_xy, delta in zip(t_list, s_xy_list, deltas):\n",
+    "    plt.plot(t, s_xy, label=r\"$\\Delta = $\"+f\"{delta:0.1f}\")\n",
+    "    plt.xlabel(r'$t/$ps')\n",
+    "    plt.ylabel(r'$<\\sigma_xy>$')\n",
+    "plt.ylim((0.0,1.0))\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "3306e98808c0871e8a1685f50cc307ae5b4a4a013844b10634a4efe89132c3fe"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 1,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/mf_tempo.ipynb
+++ b/tutorials/mf_tempo.ipynb
@@ -4,55 +4,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Time dependence and PT-TEMPO\n",
-    "Guide to using the OQuPy package to compute the dynamics of a many-body system of the type introduced in [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)). We demonstrate both the TEMPO and PT-TEMPO methods for this calculation."
+    "# Using mean-field TEMPO (TempoWithField)\n",
+    "In this tutorial we discuss how the TEMPO and PT-TEMPO methods may be used to compute the dynamics of a many-body system of the type introduced in [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)).\n",
+    "### Contents\n",
+    "  1. Background and introduction\n",
+    "    * many-body system and environment Hamiltonians\n",
+    "    * system Hamiltonian and field equation of motion after the mean-field reduction\n",
+    "  2. Creating time-dependent system with field and bath objects\n",
+    "  3. TEMPO computation for single dynamics\n",
+    "  4. PT-TEMPO computation for multiple sets of dynamics"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Contents:**\n",
-    "\n",
-    "* Example - Dicke Hamiltonian under the rotating wave approximation\n",
-    "    1. Many-body system and environment Hamiltonian\n",
-    "    2. System Hamiltonian and field equation of motion after the mean-field reduction\n",
-    "    3. Create time dependent system with field object\n",
-    "    4. TEMPO computation for single dynamics\n",
-    "    5. PT-TEMPO computation for multiple sets of dynamics"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First, import OQuPy and other relevant packages:"
+    "We firstly import OQuPy and other useful packages:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'tensornetwork'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [2]\u001b[0m, in \u001b[0;36m<cell line: 4>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01msys\u001b[39;00m\n\u001b[1;32m      2\u001b[0m sys\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39minsert(\u001b[38;5;241m0\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m..\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mmatplotlib\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mpyplot\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mplt\u001b[39;00m\n",
-      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/__init__.py:56\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[38;5;66;03m# -- Modules in alphabetical order --------------------------------------------\u001b[39;00m\n\u001b[1;32m     54\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Bath\n\u001b[0;32m---> 56\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath_dynamics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m TwoTimeBathCorrelations\n\u001b[1;32m     58\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcontractions\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m compute_correlations\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcontractions\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m compute_dynamics\n",
-      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/bath_dynamics.py:28\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m ndarray\n\u001b[1;32m     27\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbase_api\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseAPIClass\n\u001b[0;32m---> 28\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mprocess_tensor\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseProcessTensor\n\u001b[1;32m     29\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbath\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Bath\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01msystem\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseSystem\n",
-      "File \u001b[0;32m~/documents/saints/phd/tempo/OQuPy/tutorials/../oqupy/process_tensor.py:30\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[1;32m     29\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m ndarray\n\u001b[0;32m---> 30\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtensornetwork\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mtn\u001b[39;00m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mh5py\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01moqupy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbase_api\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m BaseAPIClass\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'tensornetwork'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "sys.path.insert(0,'..')\n",
-    "\n",
     "import oqupy\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -62,25 +39,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Check the installed OQuPy version; TEMPO with mean-field evolution was introduced in **?.?.0**"
+    "Check the current OQuPy version; mean-field functionality was introduced in version **?.?.0**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'0.2-dev'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "oqupy.__version__"
    ]
@@ -94,21 +60,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'oqupy' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [3]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m sigma_z \u001b[38;5;241m=\u001b[39m \u001b[43moqupy\u001b[49m\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mz\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m sigma_plus \u001b[38;5;241m=\u001b[39m oqupy\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m+\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      3\u001b[0m sigma_minus \u001b[38;5;241m=\u001b[39m oqupy\u001b[38;5;241m.\u001b[39moperators\u001b[38;5;241m.\u001b[39msigma(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m-\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'oqupy' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sigma_z = oqupy.operators.sigma(\"z\")\n",
     "sigma_plus = oqupy.operators.sigma(\"+\")\n",
@@ -120,11 +74,11 @@
    "metadata": {},
    "source": [
     "-------------------------------------------------\n",
-    "## Example - Dicke Hamiltonian under the rotating wave approximation\n",
+    "# 1. Background and introduction\n",
     "\n",
-    "Our goal will be to reproduce **Fig. 2a.** of [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)), firstly using TEMPO to obtain a single line from this figure, and then PT-TEMPO to obtain all lines in short succession. \n",
+    "Our goal will be to reproduce a line from **Fig. 2a.** of [FowlerWright2021] ([arXiv:2112.09003](http://arxiv.org/abs/2112.09003)) which shows the photon number dynamics for the driven-dissipative system of molecules in a single-mode cavity.\n",
     "\n",
-    "### 1. Many-body system and environment Hamiltonian\n",
+    "## Many-body system and environment Hamiltonian\n",
     "The Hamiltonian describing the many-body system with one-to-all light-matter coupling is\n",
     "$$\n",
     "H_{S} = \\omega_c a^{\\dagger}_{}a^{\\vphantom{\\dagger}}_{} \n",
@@ -134,19 +88,18 @@
     "Together with the vibrational environment of each molecule,\n",
     "$$\n",
     "\tH_{E}^{(i)} = \\sum_{j} \\left[\t\\nu_{j} b^{\\dagger}_{j} b^{\\vphantom{\\dagger}}_{j} \n",
-    "\t+ \\frac{\\xi_{j}}{2} (b^{\\vphantom{\\dagger}}_{j}+b^{\\dagger}_{j})\\sigma^z_i\\right]\\text{,}\n",
+    "\t+ \\frac{\\xi_{j}}{2} (b^{\\vphantom{\\dagger}}_{j}+b^{\\dagger}_{j})\\sigma^z_i\\right]\\text{.}\n",
     "$$\n",
-    "which is taken to be a continuum of low frequency modes with coupling characterized by a spectral density \n",
+    "This is taken to be a continuum of low frequency modes with coupling characterized by a spectral density with a 'Gaussian' cut-off\n",
     "$$\n",
     "\\begin{align*}\n",
     "J(\\nu) &= \\sum_{j}  \\left(\\frac{\\xi_j}{2}\\right)^2\n",
-    "\\delta(\\nu-\\nu_j) \\\\\n",
-    "&= 2\\alpha \\nu e^{-(\\nu/\\nu_c)^2}\\text{,} \\quad \\nu>0\\text{,}\n",
+    "\\delta(\\nu-\\nu_j)= 2\\alpha \\nu e^{-(\\nu/\\nu_c)^2}\\text{,} \\quad \\nu>0\\text{,}\n",
     "\\end{align*}\n",
     "$$\n",
     "where $\\alpha=0.25$ and $\\nu_c=0.15$ eV for the environment of BODIPY-Br considered in the Letter. Other system and environment parameters relevant to **Fig. 2a.** are, in units of eV,\n",
-    "* $T=0.026$ ($300$ K) - environment temperature\n",
-    "* $\\omega_0=0$ - two-level system frequency**\\***\n",
+    "* $T=0.026$ $\\left(300 \\text{K}\\right)$ - environment temperature\n",
+    "* $\\omega_0=0$ - two-level system frequency **\\***\n",
     "* $\\omega_c=-0.02$ - bare cavity frequency\n",
     "* $\\Omega=0.2$ - collective light-matter coupling\n",
     "\n",
@@ -155,52 +108,55 @@
     "* $\\Gamma_\\downarrow = 0.01$ - electronic dissipation\n",
     "* $\\Gamma_\\uparrow \\in (0.2\\Gamma_\\downarrow,0.8\\Gamma_\\downarrow) $ - electronic pumping\n",
     "\n",
-    "which appear as prefactors for Markovian terms in the quantum master equation for the total density operator\n",
+    "The latter appear as prefactors for Markovian terms in the quantum master equation for the total density operator\n",
     "$$\n",
     "\t\t\\partial_t \\rho = -i \\biggl[ H_S + \\sum_{i=1}^N H_E^{(i)}, \\rho \\biggr]\n",
     "\t+ 2 \\kappa \\mathcal{L}[a^{\\vphantom{\\dagger}}_{}]\n",
     "\t+ \\sum_{i=1}^N (\\Gamma_\\uparrow \\mathcal{L}[\\sigma^+_i]\n",
     "\t+  \\Gamma_\\downarrow \\mathcal{L}[\\sigma^-_i])\\text{.}\n",
     "$$\n",
-    "As indicated, it is the pump strength $\\Gamma_\\uparrow$ that will be varied to generate the different lines of **Fig. 2a.** All other parameters are defined in the following code box.\n",
+    "As indicated, it is the pump strength $\\Gamma_\\uparrow$ that is varied to generate the different lines of **Fig. 2a.** In this tutorial we generate the $\\Gamma_\\uparrow=0.8$ line using the TEMPO method, and then the Process Tensor approach to calculate all of the lines efficiently.  \n",
+    "\n",
+    "The following code box defines each of the above parameters.\n",
     "\n",
     "\n",
-    "**\\***N.B. for calculating the dynamics only the detuning $\\omega_c-\\omega_0$ is relevant, so we set $\\omega_0=0$ for conveninence."
+    "**\\* N.B.** for calculating the dynamics only the detuning $\\omega_c-\\omega_0$ is relevant, so we set $\\omega_0=0$ for convenience."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "alpha = 0.25\n",
     "nu_c = 0.15\n",
     "T = 0.026\n",
-    "omega_0 = 0\n",
+    "omega_0 = 0.0\n",
     "omega_c = -0.02\n",
     "Omega = 0.2\n",
     "\n",
     "kappa = 0.01\n",
-    "Gamma_down = 0.01"
+    "Gamma_down = 0.01\n",
+    "Gamma_up = 0.8 * Gamma_down"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. System Hamiltonian and field equation of motion after the mean-field reduction"
+    "### System Hamiltonian and field equation of motion after the mean-field reduction"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The mean-field approach is based on the product-state ansatz\n",
+    "The mean-field approach is based on a product-state ansatz for the total density operator $\\rho$,\n",
     "$$\n",
-    "\\rho = \\rho_a \\otimes \\bigotimes_{i=1}^N \\rho_i\n",
+    "\\rho = \\rho_a \\otimes \\bigotimes_{i=1}^N \\rho_i,\\quad \\rho_a= \\text{Tr}_{\\otimes{i}}\\rho,\\quad \\rho_i = \\text{Tr}_{a, \\otimes{j\\neq i}} \\rho,\n",
     "$$ \n",
-    "where $\\rho_a= \\text{Tr}_{\\otimes{i}}\\rho$ is obtained from the partial trace taken over the Hilbert space of all two-level systems and $ \\rho_i = \\text{Tr}_{a, \\otimes{j\\neq i}} \\rho$ from the partial trace over all but the photonic degree of freedom. As detailed in the Supplemental Material of the Letter, after rescaling the field $\\langle a \\rangle \\to \\langle a \\rangle/\\sqrt{N}$ ($\\langle a \\rangle$ scales with $\\sqrt{N}$ in the lasing phase), the dynamics are controlled by the mean-field Hamiltonian $H_{\\text{MF}}$ for a *single molecule,*\n",
+    "where $\\text{Tr}_{\\otimes{i}}$ denotes a partial trace taken over the Hilbert space of all two-level systems and $\\text{Tr}_{a, \\otimes{j\\neq i}}$ the trace over the photonic degree of freedom and all but the $i^{\\text{th}}$ two-level system. As detailed in the Supplement of the Letter, after rescaling the field $\\langle a \\rangle \\to \\langle a \\rangle/\\sqrt{N}$ ($\\langle a \\rangle$ scales with $\\sqrt{N}$ in the lasing phase), the dynamics are controlled by the mean-field Hamiltonian $H_{\\text{MF}}$ for a *single molecule,*\n",
     "$$\n",
     "\tH_\\text{MF} = \n",
     " \\frac{\\omega_0}{2}\\sigma^z+\n",
@@ -212,39 +168,17 @@
     "\\partial_t \\langle a \\rangle = \n",
     "\t- (i\\omega_c+\\kappa)\\langle a \\rangle- i \\frac{\\Omega}{2}\\langle\\sigma^-\\rangle.\n",
     "$$\n",
-    "To encode this information, and hence compute the dynamics, we use a `TimedependentSystemWithField` object. In the following we use $\\rho$ (no subscript) to denote the density operator of a a single two-level system (rather than the total many-body operator), since this forms the system in our TEMPO simulations."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3. Create time dependent system with field object\n",
-    "The `TimedependentSystemWithField` object requires two physical inputs: a Hamiltonian, which is a function of time $t$ and field value $\\langle a \\rangle$ (in that order), and a equation of motion for the field, which is a function of time $t$, two-level system state $\\rho$ and field value $\\langle a \\rangle$. Note here $\\rho$ is provided as a $2\\times2$ matrix, hence to compute the expectation $\\langle \\sigma^- \\rangle$ we must multiple $\\rho$ by $\\sigma^-$ and take the trace:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def H_MF(t, a):\n",
-    "    return 0.5 * omega_0 * sigmaz +\\\n",
-    "        0.5 * Omega * (a * sigma_plus + np.conj(a) * sigma_minus)\n",
-    "def field_eom(t, state, a):\n",
-    "    expec_val = np.matmul(sigma_minus, state).trace().real\n",
-    "    return -(1j * omega_c + kappa) * a - 0.5j * Omega * expect_val\n",
-    "    \n",
+    "Therefore in order to calculate the dynamics we need to encode the field's equation of motion in addition to the Hamiltonian for a single two level-system $\\rho_i$ (which we identify as the 'system' in our TEMPO computation). \n",
     "\n",
-    "system = oqupy.TimeDependentSystem(hamiltonian_t)\n"
+    "In OQuPy, the relevant classes and methods hence all have the `WithField` suffix: `TimeDependentSystemWithField`, `DynamicsWithField`, `TempoWithField` (TEMPO) and `compute_dynamics_with_field()` (PT-TEMPO)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition, we need to specify Lindland operators for the pumping and dissipation processes. For now we will use a pumping $\\Gamma_\\uparrow = 0.8 \\Gamma_\\downarrow$, but in the PT-TEMPO computation below this will be varied."
+    "# 2. Creating time-dependent system with field and bath objects\n",
+    "A `TimedependentSystemWithField` object requires two physical inputs: a Hamiltonian, which is a function of time $t$ and field $\\langle a \\rangle$ (in that order), and a equation of motion for the field, which is a function of time $t$, system state $\\rho_i$ and field $\\langle a \\rangle$. Positional arguments are used for these functions, so the order of arguments matters whilst their name does not:**\\***"
    ]
   },
   {
@@ -253,16 +187,56 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Gamma_up = 0.8 * Gamma_down\n",
-    "gammas = [ lambda t: Gamma_down, lambda t: Gamma_up]\n",
-    "lindblads = [ lambda t: sigma_minus, lambda t: sigma_plus]"
+    "def H_MF(t, a):\n",
+    "    return 0.5 * omega_0 * sigma_z +\\\n",
+    "        0.5 * Omega * (a * sigma_plus + np.conj(a) * sigma_minus)\n",
+    "def field_eom(t, state, a):\n",
+    "    expect_val = np.matmul(sigma_minus, state).trace()\n",
+    "    return -(1j * omega_c + kappa) * a - 0.5j * Omega * expect_val"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note the rates and linblad operators must be callables taking a single argument---time---even though in our example there is no time-dependence (there is no `SystemWithField` class). Including the above, the system is then constructed with"
+    "Note $\\rho_i$ is provided as a $2\\times2$ matrix, hence to compute the expectation $\\langle \\sigma^- \\rangle$ we used matrix multiplication with $\\sigma^-$ and took the trace. It's a good idea to test these functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_field = 1.0+1.0j\n",
+    "test_time = 1.0\n",
+    "test_state = np.array([[0.0,2j],[-2j,1.0]])\n",
+    "print('H_eval =', H_MF(test_time, test_field))\n",
+    "print('EOM_eval =', field_eom(test_time, test_state, test_field))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Secondly, we need to specify Lindblad operators for the pumping and dissipation processes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gammas = [ lambda t: Gamma_down, lambda t: Gamma_up]\n",
+    "lindblad_operators = [ lambda t: sigma_minus, lambda t: sigma_plus]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the rates and Lindblad operators must be callables taking a single argument - time - even though in our example there is no time-dependence (see **\\*** below). The system-field object is then constructed with"
    ]
   },
   {
@@ -275,14 +249,14 @@
     "        H_MF,\n",
     "        field_eom,\n",
     "        gammas=gammas,\n",
-    "        lindblad_operators=lindblads)"
+    "        lindblad_operators=lindblad_operators)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Correlations and a Bath object are created in the same way as in any other TEMPO computation (see preeceding tutorials):"
+    "Correlations and a Bath object are created in the same way as in any other TEMPO computation (refer to preceding tutorials):"
    ]
   },
   {
@@ -295,7 +269,7 @@
     "                                zeta=1,\n",
     "                                cutoff=nu_c,\n",
     "                                cutoff_type='gaussian',\n",
-    "                                temperature=temperature)\n",
+    "                                temperature=T)\n",
     "bath = oqupy.Bath(0.5 * sigma_z, correlations)"
    ]
   },
@@ -303,7 +277,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4. TEMPO computation"
+    "**\\*** In particular both functions must have a first argument representing time, even if the problem - as here - has no explicit time-dependence (for codebase simplicity there is no `SystemWithField` class)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. TEMPO computation for single dynamics"
    ]
   },
   {
@@ -327,35 +308,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "as well as the computational parameters:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100.0%   50 of   50 [########################################] 00:00:01\n",
-      "Elapsed time: 1.4s\n"
-     ]
-    }
-   ],
-   "source": [
-    "tempo_parameters = oqupy.TempoParameters(dt=0.6, dkmax=250, epsrel=10**(-4))\n",
-    "start_time = 0.0\n",
-    "end_time = 1000.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "where for the sake of reducing the computation time the precision was lowered and the simulation time halved relative to the Letter. The only sutblty here is that the units of time are those with $\\hbar=1$; you can check $t=1000$ corresponds to $t=4$ ps in SI units.\n",
-    "`oqupy.TempoWithField` and the `.compute` method may then be used to compute the dynamics in exactly the same way a call to `oqupy.Tempo` is used to compute the dynamics for an ordinary `System` or `TimeDependentSystem`:"
+    "To reduce the computation time we simulate only part of the dynamics. We also lower the memory cut-off and precision relative to the Letter and use twice the timestep size:"
    ]
   },
   {
@@ -364,11 +317,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tempo_sys = oqupy.Tempo(system=system,\n",
-    "                        bath=bath,\n",
-    "                        initial_state=initial_state,\n",
-    "                        start_time=start_time,\n",
-    "                        parameters=tempo_parameters)\n",
+    "tempo_parameters = oqupy.TempoParameters(dt=1.2, dkmax=80, epsrel=10**(-5))\n",
+    "start_time = 0.0\n",
+    "end_time = 500.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The only subtlety here is that the units of time are those with $\\hbar=1$; you can check $t=500$ corresponds to $t=2$ ps in SI units.\n",
+    "The `oqupy.TempoWithField.compute` method may then be used to compute the dynamics in exactly the same way a call to `oqupy.Tempo.compute` is used to compute the dynamics for an ordinary `System` or `TimeDependentSystem`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tempo_sys = oqupy.TempoWithField(system=system,\n",
+    "                                 bath=bath,\n",
+    "                                 initial_state=initial_state,\n",
+    "                                 initial_field=initial_field,\n",
+    "                                 start_time=start_time,\n",
+    "                                 parameters=tempo_parameters)\n",
     "dynamics_with_field = tempo_sys.compute(end_time=end_time)"
    ]
   },
@@ -376,76 +349,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note `dynamics_with_field` contains both the timesteps and state matrices at each timestel, plus the corresponding field values. We plot the latter below which describes (part of) a single curve from **Fig. 2.**"
+    "`TempoWithField.compute` returns a `DynamicsWithField` object containing both the state matrices and field values at each timestep, in addition to the timesteps themselves:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f530c8b5f28>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEMCAYAAAArnKpYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAgQklEQVR4nO3deZScdZ3v8fe39zXdWbqzdAfSIRAISACbRZRFwAGiDupcBJ3rAiriAUfv9dyRmXEGHeac8aqjzAjCRVzPlUSvgiKyDDDKIiKEJIQlAUIHk+okvdF7d1Vv3/tHVbdNp0Oqq6ue2j6vc/p0PUtVfytLffr3PL/F3B0RERGAgnQXICIimUOhICIiUxQKIiIyRaEgIiJTFAoiIjJFoSAiIlMCCQUz+76ZtZvZ84c4bmb2H2a2y8y2m9kpQdQlIiJvFFRL4YfARW9y/GLg6NjXVcAtAdQkIiIzBBIK7v4o8PqbnHIJ8GOPehKoNbPlQdQmIiJ/VpTuAmIagL3TtkOxfftnnmhmVxFtTVBZWfnWY489NpACRURyxTPPPNPp7nWzHcuUULBZ9s06/4a73wbcBtDc3OybN29OZV0iIjnHzP50qGOZ0vsoBKyctt0I7EtTLSIieStTQuFu4KOxXkhnAL3uftClIxERSa1ALh+Z2UbgXGCJmYWA64FiAHe/FbgX2ADsAoaAK4KoS0RE3iiQUHD3Dx3muAPXBFGLiIgcWqZcPhIRkQygUBARkSkKBRERmaJQEBGRKQoFERGZkikjmkXSbnR8gm17e6guK2JRZQmLKkooKtTvTZJfFAoiMbf87lW++eDLb9hXW1HM4soSGhdW8D/fdQzrV9ampziRgCgURIDw6Dg/euI13rZ6Mf/9jCN5fTBC58AIXYMRXh8cYfNr3Xzglif4zDlH8dnz11BaVJjukkVSQqEgAty1tZWuwRH+5vyjedtRiw863js8yg33vMhNv93FQzva+Mal6zmhoSYNlYqkli6YSt6bmHBuf6yFExoWcMbqRbOeU1NezDcuXc/3PtZM1+AI77v599z40MuMjk8EXK1IaikUJO/99qV2Xu0Y5FNnrcZstlnc/+z845by4P84m/euX8GND73CJTf9npcO9AdUqUjqKRQk7333sRaW15Sx4S3xLfZXW1HCty47if/zkbfS3h/mvd9+nNsfa2FiYtYlQESyikJB8tpzoV6ebHmdK9/eRPEcu59eePwy7v/82Zx9TB3/8psd/PXtf6S1ZzhFlYoEQ6Egee27j7VQVVrEZaetPPzJs1hSVcp3P/pWvvZXJ7I91MNFNz7KL7e2Ep34VyT7KBQkb7X2DPOb5/Zz+akrWVBWnPDrmBkfPHUl933ubNYurebzP93GtRu30jkQSWK1IsFQKEje+uHvdwNwxTuakvJ6Ryyu4Keffhv/68K1PPD8Ad759d9x+2MtjIyph5JkD41TkLzUFx5l41N7efdbltNQW5601y0sMK555xouPH4ZN9zzIv/ymx3c8dQe/vE963jn2vqk/RzJLe7OyPgEkbEJIqMTRMbGD348NkFk9M+Pj1laxYmNtUmvRaEgeemnT+1lIDLGp85anZLXX1NfxQ+vOJXfvtTODffs4IofPM15x9bzpXcfx+q6qpT8TElcIh/KkbHx2PF4zj/8683Vp89ZrVAQSYbR8Ql+8PvdnN60iLc0pm5Usplx3rFLeceaOn70xGv8+8OvcOGNj3LJSQ18/MxVGhH9Jtyd4dFxBiPjDI2MTX0fGhknPDrO8Gj0A3l4NLodjn3Yhqd96IanfeCOpOBDeaaSwgJKiwooLS6gpLCAsuJCSopi+4oKqSotYlFFdP/keaVF0cclRdP3x75Pfk1tR7+XxZ5XU5H4fbA3o1CQvHPf8wfY1xvmhvedEMjPKykq4FNnr+Z9Jzfw7f96hZ8/E+Lnz4Q45YhaPnbmKi4+YTklRbl3e29sfILuoVG6BiN0D47SOzxCz9AoPcOj9AxFt/vCY/SHx+gPjzIw7fHQ6Dhz7cBVVGBTH6yT30umfahWlRaxpGra/qKDP5wP/lAujB4v/PP+slk+zEsKCygoePOBj9nCsrnrXHNzs2/evDndZUiW+dIvn+PubfvY9k9/kZb/yL3Do/zimRA//sNrvNY1xJKqUj58+hH85foVHFVXedhR1enk7vRHxmjvC9PWF6G9P/q9rS9Me3+EroEIXQMjdA2O0D00csgP9uJCo6a8hAXlRVSXFbOgrIiq0iKqy6LblaVFVJYUUjH5vaSQ8pKi6PfiQsqKCykrLph6XFpUoGnO58DMnnH35tmOqaUgeaelY5DVdVVp+82upryYK9/RxMfPXMWjr3Twoyde49v/9Qr/8fArLFtQxtvXLOEdRy/m7UctoX5BWWB1uTt9w2Ps7xtmf2+Y/T1hDvQOs683zIHeMPt7o/uHRsYPem5VaRF11aXUVZWypr6K06tKWFxZypKqEhZVlrKwopjaihJqK4qprSimvLgwo8MvnykUJO/s7hzkbasPngk1aAUFxrlr6zl3bT2h7iEefbmT3+/q5OGdbfxiSwiAY5ZWccKKGhoXVbByYTmNCytYuaic5TXlFMYRapPX5gciY/QOjdLRH6FjIBL9Hvtq6w+zP/bBP/MDv8CgvrqM5bVlrF1WzTnH1LOsppSlC8pYuqCM+upS6heUUVWqj5Jcob9JyStDI2Ps7w2zuq4y3aW8QePCCj58+hF8+PQjmJhwXtzfx+O7oiHxh5YuDmxrfcOlmKICY0F5MUUFRnFhAUWFNvV4fMIZiIwxEBljMDLGoaZkKikqoL66lLrqUo5btoB3rq1neU0Zy2vKWVZTxvKa6Ie+LsvkF4WC5JXdnYMANC3J3G6hBQXGCQ01nNBQw9XnHAXAyNgE+3qGCXUPs7d7iL2vD9EXHmVs3Bkdd8YmJmKPJygsMKpKi6gsjV6nryqLPq4pL6auKhoCddWlLCgr0iUcOYhCQfJKS0c0FDKtpXA4JUUFrFpSyaol2VW3ZB+1CyWvTLYUVi3Wh6vIbBQKkldaOgZoqC2nvERrLIvMRqEgeWV35yBNugQjckgKBckb7h4bo6BQEDkUhYLkjc6BEfojY2opiLwJhYLkjZaOAQDNUiryJhQKkjcmex6tVktB5JAUCpI3WjoHKSkqYEUSF9URyTUKBckbLR2DrFpcEdecQSL5KrBQMLOLzOwlM9tlZtfNcrzGzH5tZs+a2QtmdkVQtUl+aOkcYHUGT28hkgkCCQUzKwRuBi4G1gEfMrN1M067BnjR3dcD5wL/ZmYlQdQnuW90fII9XUPqjipyGEG1FE4Ddrl7i7uPAJuAS2ac40C1RWfoqgJeB8YCqk9yXKh7mLEJV3dUkcMIKhQagL3TtkOxfdPdBBwH7AOeAz7n7gctnGpmV5nZZjPb3NHRkap6JceoO6pIfIIKhdnu7M2c5f1CYBuwAjgJuMnMFhz0JPfb3L3Z3Zvr6uqSXafkKHVHFYlPUKEQAlZO224k2iKY7grgTo/aBewGjg2oPslxr3YMsrCimIWVuk0l8maCCoWngaPNrCl28/hy4O4Z5+wBzgcws6XAWqAloPokx+3uHND9BJE4BBIK7j4GXAs8AOwAfubuL5jZ1WZ2dey0G4Azzew54GHgi+7eGUR9kvuiE+HpfoLI4QS28pq73wvcO2PfrdMe7wP+Iqh6JH8MRMZo74+opSASB41olpy3O7YE51EaoyByWAoFyXktndHuqE0azSxyWAoFyXktHYOYwZGLK9JdikjGUyhIztvdOUhDbTllxVqXWeRwFAqS81o6B9TzSCROCgXJae7O7o5BjWQWiZNCQXJae3+EwZFxzY4qEieFguS0llh3VI1REImPQkFy2mR3VN1TEImPQkFy2u6OQcqKC1i+oCzdpYhkBYWC5LSWzkFWLa6kQOsyi8RFoSA5bXfnoG4yi8yBQkFy1sjYBHteH2K1prcQiZtCQXLW3u4hxrUus8icKBQkZ012R9XlI5H4KRQkZ+2e7I6qy0cicVMoSM56rWuIhRXF1FQUp7sUkayhUJCc1dYbZnlNebrLEMkqCgXJWW39YZYuKE13GSJZRaEgOetAb4RlNRrJLDIXCgXJSaPjE3QNRqivViiIzIVCQXJS50AEd1iqOY9E5kShIDmprS8CoHsKInOkUJCcdKA3DKilIDJXCgXJSe39CgWRRCgUJCe19YUpLDAWV5akuxSRrKJQkJzU1hehvrpU6yiIzJFCQXJSW19Yl45EEqBQkJwUDQX1PBKZK4WC5KS2vohaCiIJUChIzgmPjtM7PKpQEEmAQkFyTnts4Fp9tS4ficyVQkFyzoG+6BgFTYYnMncKBck5bX0auCaSqMBCwcwuMrOXzGyXmV13iHPONbNtZvaCmT0SVG2SW6ZCQTOkisxZURA/xMwKgZuBdwEh4Gkzu9vdX5x2Ti3wHeAid99jZvVB1Ca5p70/QmlRAQvKA/nnLZJTgmopnAbscvcWdx8BNgGXzDjnw8Cd7r4HwN3bA6pNcsyB3jDLasow02hmkbkKKhQagL3TtkOxfdMdAyw0s9+Z2TNm9tHZXsjMrjKzzWa2uaOjI0XlSjZr6wvr0pFIgoIKhdl+ZfMZ20XAW4F3AxcC/2hmxxz0JPfb3L3Z3Zvr6uqSX6lkvfb+CPUazSySkKBCIQSsnLbdCOyb5Zz73X3Q3TuBR4H1AdUnOcLdNe+RyDwEFQpPA0ebWZOZlQCXA3fPOOdXwFlmVmRmFcDpwI6A6pMc0R8ZY2hknGUKBZGEBNI9w93HzOxa4AGgEPi+u79gZlfHjt/q7jvM7H5gOzAB3O7uzwdRn+SO9lh3VF0+EknMnELBzJqB7bEeRHPi7vcC987Yd+uM7a8DX5/ra4tM+vPazGopiCQi7stHZrYceAL4YOrKEZkfjWYWmZ+53FP4GPAj4JMpqkVk3g5MhYIuH4kkYi6h8BHg74ASMzsqRfWIzEt7X4TqsiIqSjSaWSQRcYWCmb0T2BnrKvoD4BMprUokQeqOKjI/8bYUPgF8L/b4p8ClZqYZViXjaBlOkfk57Ad7bKK6M4D7ANy9D3gS2JDSykQSoGU4RebnsBde3b0HWDNj30dSVZBIoiYmnPZ+XT4SmQ9dApKc0T00wui4s1TLcIokLN4bzQ+ZmeYhkoymgWsi8xdvS+FvgW+Z2Q9ig9hEMk5bf2yMgtZmFklYXKHg7lvc/TzgHuB+M7vezMpTW5rI3LT1ajSzyHzNZZoLA14CbgE+C7xiZrrhLBlj8vJRXZXuKYgkKt57Co8DrcC3iK6Y9nHgXOA0M7stVcWJzEVbf5jFlSWUFKn/hEii4p0L4GrgBXefuVraZ81Max5IRmjXaGaReYv3nsLzk4FgZoUzDr876VWJJOCARjOLzFsi7ezbYiujYWZnu3tLkmsSSYhGM4vMXyJTSf4T8D0zGwO2EV1LWSStxsYn6ByIUK9QEJmXRFoKNxDtheTAz5JbjkhiOgdGcNc6CiLzFW/vo+unbf6tu38Z+Axw/ezPEAnW5Ipry9RSEJmXeC8fXR+7j7AI2GJmm9y928w+ncLaROJ2QMtwiiRFvJePHAgDDwArgSfMbL27j6esMpE5aI+FQr0uH4nMS7wthZ3uPnmp6Odm9kPgVuC8lFQlMkdtfREKC4zFlQoFkfmIt6XQaWZvndxw95eButSUJDJ3bX1h6qtLKSywdJciktXibSn8DbDJzJ4BngNOBHanrCqROTrQF1Z3VJEkiHdE87PAScDG2K7fAh9KUU0ic9beF9HiOiJJEPfgNXePAL+JfYlklLb+MKc1LUp3GSJZT9NJStYLj47TMzTKMi2uIzJvCgXJeu2xdRTqdflIZN4OGwpmVjFzfWYzO8LMGlJXlkj8ppbh1I1mkXmLp6UwCtxpZpXT9t0OaK1myQhtGs0skjSHDQV3HwXuAi6DaCsBqHP3zSmuTSQuk8twat4jkfmL957C7cAVsccfBX6QmnJE5q6tL0xpUQELyhOZCV5Epovrf5G77zQzzOwYouMT3pHaskTi19YXpn5BKWYazSwyX3PpffQ9oi2G7e7enaJ6ROZsX88wK2rK012GSE6YSyj8DFhPNBxEMkZr9zANCxUKIskQdyi4+5C717j7Q4n8IDO7yMxeMrNdZnbdm5x3qpmNm9l/S+TnSH4ZHZ/gQF+YhlqFgkgyBDJ4zcwKgZuBi4F1wIfMbN0hzvvfRNdtEDmstr4wE45CQSRJghrRfBqwy91b3H0E2ARcMst5nwV+AbQHVJdkudbuYQBdPhJJkqBCoQHYO207FNs3JTZC+v1EF+85JDO7ysw2m9nmjo6OpBcq2aW1JxYKaimIJEVQoTBbX0GfsX0j8MXDLfHp7re5e7O7N9fVaZ2ffDfZUlihUBBJiqBG+4SIru08qRHYN+OcZqIL+QAsATaY2Zi7/zKQCiUrtfYMs6SqlLLiwnSXIpITggqFp4GjzawJaAUuBz48/QR3b5p8HFsD+h4FghxOa4+6o4okUyCXj9x9DLiWaK+iHcDP3P0FM7vazK4OogbJTa3dwzTq0pFI0gQ2WYy73wvcO2PfrDeV3f3jQdQk2c3dae0Z5oJ1S9NdikjO0CI7krU6B0aIjE2o55FIEikUJGtNdkdVzyOR5FEoSNaaGrimUBBJGoWCZK19PRrNLJJsCgXJWq09w1SXFlFTXpzuUkRyhkJBslZIU2aLJJ1CQbJWa8+w7ieIJJlCQbJWa/eQWgoiSaZQkKzUHx6lLzymloJIkikUJCu1queRSEooFCQracpskdRQKEhWmmwpaDI8keRSKEhWau0epqSwgCVVpekuRSSnKBQkK4V6hllRW0ZBwWyL+olIohQKkpX2aXEdkZRQKEhWau3WwDWRVFAoSNaJjI3T3h+hobYi3aWI5ByFgmSd/T1hQGMURFJBoSBZZ2rgmi4fiSSdQkGyzuTAtUa1FESSTqEgWSfUM4wZLF1Qlu5SRHKOQkGyTmv3MEuryygp0j9fkWTT/yrJOq09mjJbJFUUCpJ1tLiOSOooFCSrjE84B3rDaimIpIhCQbJKR3+E0XFXS0EkRRQKklVae4YADVwTSRWFgmSVULfWURBJJYWCZJXJ0cxacU0kNRQKklVau4eprSimsrQo3aWI5CSFgmQVdUcVSS2FgmQVraMgkloKBcka7h5tKajnkUjKKBQka/QMjTI0Mq6WgkgKBRYKZnaRmb1kZrvM7LpZjv+1mW2PfT1hZuuDqk2yw2TPI02ZLZI6gYSCmRUCNwMXA+uAD5nZuhmn7QbOcfcTgRuA24KoTbLHnxfX0TKcIqkSVEvhNGCXu7e4+wiwCbhk+gnu/oS7d8c2nwQaA6pNssTk4jq6pyCSOkGFQgOwd9p2KLbvUD4B3DfbATO7ysw2m9nmjo6OJJYoma61Z5jy4kIWVhSnuxSRnBVUKNgs+3zWE83eSTQUvjjbcXe/zd2b3b25rq4uiSVKpmvtjvY8Mpvtn5OIJENQw0JDwMpp243AvpknmdmJwO3Axe7eFVBtkiVe7RjgyEW6nyCSSkG1FJ4GjjazJjMrAS4H7p5+gpkdAdwJfMTdXw6oLskSvcOjvNI+wEkra9NdikhOC6Sl4O5jZnYt8ABQCHzf3V8ws6tjx28F/glYDHwndnlgzN2bg6hPMt+ze3sAOPmIhektRCTHBTarmLvfC9w7Y9+t0x5/EvhkUPVIdtm6pwczWL+yJt2liOQ0jWiWrLBlTzfH1FdTXaaeRyKppFCQjDcx4Wzb28MpR9amuxSRnKdQkIzX0jlI7/AoJ6/U/QSRVFMoSMbbuic60F0tBZHUUyhIxtuyp4cFZUWsXlKV7lJEcp5CQTLe1j3dnHTEQgoKNJJZJNUUCpLRBiJjvNzWz8katCYSCIWCZLTte3uYcDjlSN1kFgmCQkEy2pbYTeaTGmvTW4hInlAoSEbbuqeHNfVV1Gi6bJFAKBQkY7k7W/f26H6CSIAUCpKx/tQ1xOuDI7qfIBIghYJkrMn7CScfUZveQkTySGCzpIrM1dY9PVSVFnF0fXW6S5EMNjo6SigUIhwOp7uUjFNWVkZjYyPFxfHfk1MoSMbasqeb9StrKNSgNXkToVCI6upqVq1apaVap3F3urq6CIVCNDU1xf08XT6SjDQ0MsbOA/2cokV15DDC4TCLFy9WIMxgZixevHjOLSiFgmSk7aFexidc9xMkLgqE2SXy56JQkIy0dU8PgKbLFgmYQkEy0pY93TQtqWRhZUm6SxHJKwoFyTjuztY9Pbp0JJIGCgXJOKHuYToHIpysm8ySZe666y7MjJ07d87rde6//37Wrl3LmjVr+OpXv5rwOYlQKEjGmRy0dopaCpJlNm7cSHNzM5s2bUr4NcbHx7nmmmu47777ePHFF9m4cSMvvvjinM9JlMYpSMbZuqeHipJC1i7VoDWZm6/8+gVe3NeX1Ndct2IB17/3+MOeNzAwwCOPPMKDDz7IpZdeype//OWEft5TTz3FmjVrWL16NQCXX345v/rVr1i3bt2czkmUQkEyirvzZEsXJzbWUFSohqxkj1/+8pdccMEFnHjiiVRWVrJlyxZOOeWUqeNnnXUW/f39Bz3vG9/4BhdccMHUdmtrKytXrpzabmxs5I9//OMbnhPPOYlSKEhGuWf7fnYe6OdfP/CWdJciWSie3+hTZePGjVx11VUAfPCDH2Tjxo1vCIXHHnssrtdx94P2zRxvEM85iVIoSMYYHhnnX+/dwbrlC/hg88rDP0EkQ3R1dfHUU09x5513AnDZZZdxzjnn8LWvfW3qwzrelkJjYyN79+6d2g6FQqxYseINz4nnnEQpFCRj3PrIq+zrDXPj5SdrviPJKj//+c/ZsGEDpaWlADQ1NbFs2TIef/xxzjrrLCD+lsKpp57KK6+8wu7du2loaGDTpk3ccccdcz4nUQoFyQih7iFufeRV3nPick5rWpTuckTmZOPGjWzfvp1Vq1ZN7evq6uKOO+6YCoV4FRUVcdNNN3HhhRcyPj7OlVdeyfHHRy+Lbdiwgdtvv50VK1Yc8pz5stmuTWWL5uZm37x5c7rLkCS45idbeHhnGw9/4VwaasvTXY5kkR07dnDcccelu4yMNdufj5k94+7Ns52v7h2Sdn94tYvfPLefq885SoEgkmYKBUmr8QnnK79+gYbacj599lHpLkck7ykUJK02PrWHnQf6+fsNx1FeUpjuciRLZfNl8FRK5M9FoSBp0zs0yr/950uc3rSIDW9Zlu5yJEuVlZXR1dWlYJhhcuW1srKyOT1PvY8kLcbGJ/jq/TvoHR7l+vcer0VSJGGNjY2EQiE6OjrSXUrGmVyjeS4UChKo8Og4/++ZELc9+ip7Xx/m42euYt2KBekuS7JYcXHxnNYgljcXWCiY2UXAvwOFwO3u/tUZxy12fAMwBHzc3bcEVZ+kVu/wKP/3yT/xg9/vpnNghJNW1vKld6/jXcctTXdpIjJNIKFgZoXAzcC7gBDwtJnd7e7T53q9GDg69nU6cEvsu2Qwd2fCo72IxiYm6B4apWsgQtfACJ0DEToHRtjbPcTd2/YxEBnjnGPq+My5R3F60yJdMhLJQEG1FE4Ddrl7C4CZbQIuAaaHwiXAjz16t+hJM6s1s+Xuvj/Zxdz//AG+8LNtyX7ZnDP9tt30e3iOMzEB4+6MTxz+5l55cSEXrFvK1ees5vgVNckvVESSJqhQaAD2TtsOcXArYLZzGoA3hIKZXQVcFdscMLOXEqxpCdCZ4HOzVdre807gpnT8YP095wu957k58lAHggqF2a4TzPwVM55zcPfbgNvmXZDZ5kMN885Ves/5Qe85P6TqPQc1TiEETJ8LuRHYl8A5IiKSQkGFwtPA0WbWZGYlwOXA3TPOuRv4qEWdAfSm4n6CiIgcWiCXj9x9zMyuBR4g2iX1++7+gpldHTt+K3Av0e6ou4h2Sb0ixWXN+xJUFtJ7zg96z/khJe85q6fOFhGR5NLcRyIiMkWhICIiU/I6FMzs62a208y2m9ldZlab7ppSzcwuNbMXzGzCzHK6C5+ZXWRmL5nZLjO7Lt31pJqZfd/M2s3s+XTXEgQzW2lmvzWzHbF/059Ld02pZmZlZvaUmT0be89fSfbPyOtQAB4ETnD3E4GXgb9Lcz1BeB74APBougtJpWlTq1wMrAM+ZGbr0ltVyv0QuCjdRQRoDPiCux8HnAFckwd/xxHgPHdfD5wEXBTrrZk0eR0K7v6f7j4W23yS6NiInObuO9w90VHg2WRqahV3HwEmp1bJWe7+KPB6uusIirvvn5w00937gR1EZ0HIWR41ENssjn0ltbdQXofCDFcC96W7CEmaQ02bIjnIzFYBJwN/THMpKWdmhWa2DWgHHnT3pL7nnF9PwcweAmZb1usf3P1XsXP+gWhT9CdB1pYq8bznPBDXtCmS/cysCvgF8Hl370t3Panm7uPASbF7oHeZ2QnunrT7SDkfCu5+wZsdN7OPAe8BzvccGbRxuPecJzRtSh4ws2KigfATd78z3fUEyd17zOx3RO8jJS0U8vryUWzhny8Cf+nuQ+muR5IqnqlVJIvFFub6HrDD3b+Z7nqCYGZ1k70kzawcuIDoJMRJk9ehQHQ252rgQTPbZma3prugVDOz95tZCHgb8BszeyDdNaVCrAPB5NQqO4CfufsL6a0qtcxsI/AHYK2ZhczsE+muKcXeDnwEOC/2/3ebmW1Id1Epthz4rZltJ/qLz4Pufk8yf4CmuRARkSn53lIQEZFpFAoiIjJFoSAiIlMUCiIiMkWhICIiUxQKIiIyRaEgIiJTFAoi82RmjWZ22Yx9q8zs3th6Di+bWT5Myy45QKEgMn/nA6dMbphZAdH5eG5197XAW4BmM7sqTfWJxE0jmkXmwczeAfwK6AH6gfcDxwKfdPe/mnbecuARdz8mHXWKxEstBZF5cPfHic5Bc4m7n+Tuu4HjgGdnnLcfWBCbnE8kYykUROZvLTB9NbtxoGr6CbEZPSuIrtshkrEUCiLzYGaLgV53H522+3fAhlgQTHoXsMXdJ4KsT2SuFAoi89PEjMV73P1ZYCvwzwBmthT4JvD3gVcnMkcKBZH52QksMbPnzexMADO7DmgGvmRm5wG3AEcC34mtJSySsdT7SEREpqilICIiUxQKIiIyRaEgIiJTFAoiIjJFoSAiIlMUCiIiMkWhICIiU/4/58Lv7APTZIIAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "t, s_x = dynamics.expectations(sigma_x, real=True)\n",
-    "t, s_y = dynamics.expectations(sigma_y, real=True)\n",
-    "s_xy = np.sqrt(s_x**2 + s_y**2)\n",
-    "plt.plot(t, s_xy, label=r'$\\Delta = 0.0$')\n",
-    "plt.xlabel(r'$t\\,\\Omega$')\n",
-    "plt.ylabel(r'$<\\sigma_xy>$')\n",
-    "plt.ylim((0.0,1.0))\n",
-    "plt.legend(loc=4)"
+    "times = dynamics_with_field.times\n",
+    "states = dynamics_with_field.states\n",
+    "fields = dynamics_with_field.fields"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5. Using PT-TEMPO to explore many different laser pulses\n",
-    "If we want to do the same computation for a set of different laser pulses (and thus different time dependent system Hamiltonians), we could repeate the above procedure. However, for a large number of different system Hamiltonians this is impractical. In such cases one may instead use the process tensor approach (PT-TEMPO) wherein the bath influence tensors are computed separately from the rest of the network. This produces an object known as the process tensor which may then be used with many different system Hamiltonians at relatively little cost."
+    "We plot a the square value of the fields i.e. the photon number, producing the first part of a single line of **Fig. 2a.**:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100.0%   50 of   50 [########################################] 00:00:01\n",
-      "Elapsed time: 1.3s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "tempo_parameters = oqupy.TempoParameters(dt=0.1, dkmax=20, epsrel=10**(-4))\n",
+    "n = np.abs(fields)**2\n",
+    "plt.plot(times, n, label=r'$\\Gamma_\\uparrow = 0.8\\Gamma_\\downarrow$')\n",
+    "plt.xlabel(r'$t$ (ps)', fontsize=16)\n",
+    "plt.yticks(ticks=[0,0.05,0.1,0.15],fontsize=14)\n",
+    "plt.xticks(ticks=[0,250,500], labels=['0','1','2'], fontsize=14)\n",
+    "plt.ylabel(r'$n/N$', fontsize=16)\n",
+    "plt.ylim((0.0,0.15))\n",
+    "plt.legend(fontsize=16, loc='lower right');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you have the time you can calculate the dynamics to $t=2000$ as in the Letter and check that, even for these rough parameters, the results are reasonable close to being converged with respect to `dt`, `dkmax` and `epsrel`.\n",
     "\n",
+    "While you could repeat the TEMPO computation for each pump strength $\\Gamma_\\uparrow$ appearing in **Fig. 2a.**, a more efficient solution for calculating dynamics for multiple sets of system parameters (in this case Lindblad rates) is provided by PT-TEMPO."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4. PT-TEMPO computation for multiple sets of dynamics\n",
+    "The above calculation can be performed quickly for many-different pump strengths  $\\Gamma_\\uparrow$ using a single process tensor. \n",
+    "\n",
+    "As discussed in the Supplement Material for the Letter, there is no guarantee that computational parameters that gave a set of converged results for the TEMPO method will give converged results for a PT-TEMPO calculation. For the sake of this tutorial however let's assume the above parameters continue to be reasonable. The process tensor to time $t=500$ ($2$ ps) is calculated using these parameters and the bath via"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "process_tensor = oqupy.pt_tempo_compute(bath=bath,\n",
-    "                                        start_time=-2.0,\n",
-    "                                        end_time=3.0,\n",
+    "                                        start_time=0.0,\n",
+    "                                        end_time=500,\n",
     "                                        parameters=tempo_parameters)"
    ]
   },
@@ -453,27 +421,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given we want to calculate $\\langle\\sigma_{xy}\\rangle(t)$ for 5 different laser pulse detunings, we define a seperate system object for each laser pulse:"
+    "Refer the Time Dependence and PT-TEMPO tutorial for further discussion of the process tensor.\n",
+    "\n",
+    "To calculate the dynamics for the 4 different pump strengths in **Fig. 2a.**, we define a separate system with field object for each pump strength. Only the `gammas` array needs to be modified constructor calls:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "deltas = [-10.0, -5.0, 0.0, 5.0, 10.0]\n",
+    "pump_ratios = [0.2, 0.4, 0.6, 0.8]\n",
     "systems = []\n",
-    "for delta in deltas:\n",
-    "    # NOTE: omitting \"delta=delta\" in the parameter definition below\n",
-    "    #       would lead to all systems having the same detuning.\n",
-    "    #       This is a common python pitfall. Check out \n",
-    "    #       https://docs.python-guide.org/writing/gotchas/#late-binding-closures\n",
-    "    #       for more information on this.\n",
-    "    def hamiltonian_t(t, delta=delta): \n",
-    "        return delta/2.0 * sigma_z \\\n",
-    "            + gaussian_shape(t, area = np.pi/2.0, tau = 0.245)/2.0 * sigma_x \n",
-    "    system = oqupy.TimeDependentSystem(hamiltonian_t)\n",
+    "for ratio in pump_ratios:\n",
+    "    Gamma_up = ratio * Gamma_down\n",
+    "    # N.B. a default argument is used to avoid the late-binding closure issue\n",
+    "    # discussed here: https://docs.python-guide.org/writing/gotchas/#late-binding-closures\n",
+    "    gammas = [ lambda t: Gamma_down, lambda t, Gamma_up=Gamma_up: Gamma_up]\n",
+    "     # Use the same Hamiltonian, equation of motion and Lindblad operators\n",
+    "    system = oqupy.TimeDependentSystemWithField(H_MF,\n",
+    "        field_eom,\n",
+    "        gammas=gammas,\n",
+    "        lindblad_operators=lindblad_operators)\n",
     "    systems.append(system)"
    ]
   },
@@ -481,82 +451,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then use the process tensor to compute the dynamics for each laser pulse"
+    "We can then use `compute_dynamics_with_field` to compute the dynamics at each $\\Gamma_\\uparrow$ for the particular initial condition using the process tensor calculated above:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "..... done.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "s_xy_list = []\n",
     "t_list = []\n",
-    "for system in systems:\n",
-    "    dynamics = oqupy.compute_dynamics(\n",
+    "n_list = []\n",
+    "for i,system in enumerate(systems):\n",
+    "    print('Gamma_up/Gamma_down = {}: computing dynamics...'\\\n",
+    "          ''.format(pump_ratios[i]), end=' ', flush=True)\n",
+    "    dynamics = oqupy.compute_dynamics_with_field(\n",
     "        process_tensor=process_tensor,\n",
     "        system=system,\n",
     "        initial_state=initial_state,\n",
-    "        start_time=-2.0)\n",
-    "    t, s_x = dynamics.expectations(sigma_x, real=True)\n",
-    "    _, s_y = dynamics.expectations(sigma_y, real=True)\n",
-    "    s_xy = np.sqrt(s_x**2 + s_y**2)\n",
-    "    s_xy_list.append(s_xy)\n",
+    "        initial_field=initial_field,\n",
+    "        start_time=0.0)\n",
+    "    t = dynamics.times\n",
+    "    fields = dynamics.fields\n",
+    "    n = np.abs(fields)**2\n",
     "    t_list.append(t)\n",
-    "    print(\".\", end=\"\", flush=True)\n",
-    "print(\" done.\", flush=True)"
+    "    n_list.append(n)\n",
+    "    print(\"done.\",flush=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and plot $\\langle\\sigma_{xy}\\rangle(t)$ for each:"
+    "Finally, plotting the results:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f530c7e8588>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA+G0lEQVR4nO3deXxcdb34/9f7zJLJ2uxJk7RJutCdtUALtCoCQlUQFGSRgsAFvoJ61ety9XsV9d7r+vPqV1FkEVGxXESBAgVZLEvZSkHoku5L2jRpJ02zTyaZ5fP740zSSZrSpJ01eT8fj+Gsc857Sjvv+ZzzOZ+3GGNQSimlAKxkB6CUUip1aFJQSik1QJOCUkqpAZoUlFJKDdCkoJRSaoAmBaWUUgMSkhRE5Hci4hWR9UfYLiLy/0Rkm4isFZFTExGXUkqpwRLVUvg9cOH7bL8ImB553Qz8JgExKaWUGiIhScEY8zJw8H12uQT4g7G9AeSLyMRExKaUUuoQZ7IDiKgE9kQtN0TWNQ3dUURuxm5NkJ2dfdrMmTMTEqBSSo0Vb7/99gFjTMlw21IlKcgw64Ydf8MYczdwN8D8+fPNmjVr4hmXUkqNOSJSf6RtqdL7qAGYFLVcBTQmKRallBq3UiUpLAeWRnohLQDajTGHXTpSSikVXwm5fCQiy4APAsUi0gB8B3ABGGPuAlYAS4BtgA/4bCLiUkopNVhCkoIx5qqjbDfAbbE4VyAQoKGhAb/fH4vDjUsej4eqqipcLleyQ1FKJViq3GiOmYaGBnJzc6mpqUFkuPvX6v0YY2hpaaGhoYHa2tpkh6OUSrBUuacQM36/n6KiIk0Ix0hEKCoq0paWUuPUmEsKgCaE46R/fkqNX2MyKSillDo2mhSUUkoN0KSglFJqgCaFOHr00UcRETZt2hSzY95www2UlpYyd+7cw7Y988wzzJgxg2nTpvHDH/5w2PePZJ/xasOBDdz87M18aeWXuOO1O/j52z/n9+t/z6NbH+WNpjcIm3CyQ1Qq7sZcl9RUsmzZMubPn89DDz3EHXfcEZNjXn/99dx+++0sXbp00PpQKMRtt93Gc889R1VVFaeffjoXX3wxs2fPHtU+49kv//lL3mt+j4nZE2nrbaO9t52gCQ5sP7P8TO446w6qcquSGKVS8aUthTjp6uripZde4r777mPZsmUxO+7ixYspLCw8bP3q1auZNm0aU6ZMwe12c+WVV/L444+Pep/xamvrVl5tfJUb593IY594jBc//SLvXPsOr1/1Ok9f9jT/seA/WN+ynsuWX8ayTcu01aDGrDHdUvjuExuoa+yI6TFnV+TxnY/POep+jz32GOeddx4nnngi2dnZvPPOO5x66qGCcosWLaKzs/Ow9/30pz/lvPPOG3Vce/fuZdKkQ2MKVlVV8eabb456n/HqD3V/wOPwcMUJVwysExFy3DnkuHO4YsYVLKpcxHdf/y7//eZ/8+yuZ/neWd9jUt6k9zmqUulnTCeFZFq2bBk333wzAFdccQXLli0blBReeeWVmJ7PHilksKHPG4xkn/HoQM8BntrxFJdNv4x8T/4R95uYM5HfnPcbHtv2GD9+68d88olP8sVTv8hVM6/CEm10q7FhTCeFkfyij4eWlhZWr17N3/72NwA+/elP84EPfIAf//jHA1/CI20p3Hnnndxzzz0ArFixgoqKimHPWVVVxZ49h+oUNTQ0HLbvSPYZj/688c8Ew0GWzl561H1FhEunX8rCioV87/Xv8cPVP+Qfu//Bf579n0zM0WKBagwwxqTt67TTTjND1dXVHbYu0e666y6zdOnSQetOP/108/LLL8fk+Dt37jRz5swZtC4QCJja2lqzY8cO09vba0488USzfv36Ue/TLxX+HBOhu6/bnL3sbPOFF74w6veGw2Hz1y1/NWf86Qyz4MEFZvm25SYcDschSqViC1hjjvC9qm3eOFi2bBlPPPEENTU1A6+NGzfy5z//+biPfdVVV7Fw4UI2b95MVVUV9913HwBOp5Nf/epXfOQjH2HWrFlcccUVzJljt5SWLFlCY2Pj++4zXi3fvpz23naum3PdqN8rIlw2/TIeufgRTig4gW+u+iZfeekrtPpb4xCpUokhZpjrzOliuHKcGzduZNasWUmKaOwYD3+OoXCIix+7mAkZE3hwyYPHdX8lFA7xQN0D/PKfvyQ/I5/vnfU9FlUtimG0SsWOiLxtjJk/3DZtKahx68U9L7K7czdL5yw97hvuDsvBDXNv4KGPPkSBp4DPvfA5vvby19jXvS82wSqVIJoU1Lj1QN0DVGRXcN7k0XcBPpIZhTN46KMPccuJt/BC/Qtc/NjF/Pa93+IP6lDkKj1oUlDj0trmtfzT+08+M/szOK3YdsJzO9zcfsrtLL90OedUnsOv3v0Vn3j8EzxX/9yw3YKVSiWaFNS49MCGB8h15XLZ9Mvido7KnEp+9sGfce8F95LpzOTLL36Zm569iXf2v6PJQaUsTQpq3GnobOD53c/zqRmfItuVHffznTnxTP7y8b/wzTO/yebWzVz3zHVc+dSVLN++nL5QX9zPr9RoaFJQ484TO57AGMPVM69O2DmdlpOrZl7Fs598lv9Y8B/4g36+tepbXPDIBfz63V9zoOdAwmJR6v2M6SealRrO9rbtVOZUUp5dnvBzZ7myuGLGFVx+wuW83vQ6D258kN+89xvuWXcPCyYu4OyKszmr8ixq82p1CBKVFJoU1LhT31FPzYSapMYgIpxVcRZnVZxFfUc9D29+mJcbXuZHb/0I3oKJ2RMHtp9YciKlWaUpP75SKBwiZEIEw0HCJkzIhAamxhgMZmAaTRBEZNDUEguH5cAhDns+aqrJMr40KcTRo48+ymWXXcbGjRuZOXNmTI5ZU1NDbm4uDocDp9PJ0If3+j3zzDN88YtfJBQKcdNNN/GNb3wjJudPd2ETpr6jnvllwz63kxTVedV89fSv8tXTv8rerr28uvdVXmt8jWd2PcNft/4VAI/Dw6S8SdTk1TA5dzLVedWUZJWQ5cwi25VNljOLTFcm2a5snJbT/jKOfEn3fzEHQgH8IT/+oJ+eYA/+kJ+eQA89QfvlC/rwBXyDpv6gn95Qr/2eUA+9wV78IT99oT77Fe4jEArQF+5L6HDi/cmhP1n0v4YmEaflHFh2iAPLsued4sTtcONyuHBbbtwON27LXu5PSpZYiAgWkWlUUoqeOsSBw7KP2Z/InJYTpzhxOVw4LScu69C0/zxuh3tg2e1wD0qM/ecE+9Jj/74uyxX3xKhJIY7iUWQHYOXKlRQXFx9xuxbTOTKvz0tPsIeavJpkhzKsypxKrphxBVfMuIJAOMD6A+vZ2rqV+o566jvq2dq6lZW7Vw4q/hNrbstNlisLj9NDpjMTj8Oe5rhyKPIU4XF4DvtCdVku+wsw6osx+su5v5Uz8MUX+fLrbzn0JxRjDGHChE142MRmjBlYDpuwvW94cKukf9twLZZQ2J4PmACBUIDeYC+d4U76Qn0Ewva6/niGxjLcuujzJYoguB1urptzHZ8/5fMxP74mhTjpL7Lz3HPPcfnll8c0KRxNdDEdYKCYjiYF2NWxCyDpl49GwmW5OKX0FE4pPWXQ+mA4SFNXEy3+FnxBHz2BHrqD3QO/7gOhwLBfzE7LSaYzc+DlcXrsL35HJlmuLLJcWWQ6M3FZriR94vTVn8CCJmhPw0GCJkgwHCQQCtgJJxwgGA7SF+4b3NKKJKOwCQ9cYus/psHYx4i8fyB5hQOcVHJSXD7L2E4KT38D9q2L7THL58FFR69tHK8iOyLCBRdcgIhwyy23DNRsiKbFdI5sV/suwL5kk66clpNJeZO0wE8KscTCcli4SP+EOraTQhLFq8jOq6++SkVFBV6vl/PPP5+ZM2eyePHiQfsM92CU3pyz1XfUk+nMpCyrLNmhKJWSxnZSGMEv+nhIRJGd0tJSLr30UlavXn1YUtBiOke2s2MnNXk1miSVOoKxnRSS5JFHHmHJkiVkZGQAUFtbS3l5OatWrWLRIns45ZG2FG677TZuu+02ALq7u+ns7CQ3N5fu7m6effZZvv3tbx/2ntNPP52tW7eyc+dOKisreeihh2JSy2EsqG+vZ27x3GSHoVTK0qQQB8uWLWPt2rXU1NQMrGtpaeHPf/7zQFI4Fvv37+fSSy8FIBgMcvXVV3PhhRcObF+yZAn33nsvFRUVA8V0QqEQN9xww7gvpgPQF+qjsbuRj039WLJDUSplaVKIgxdffDEux50yZQrvvffeEbevWLFiYH7JkiUsWbIkLnGkqz2dewib8JFvMm98El74Hpz7LZh9SWKDUypFpPYjkkrFUH/Po9q82sM39rTCk/8KB7fDw0vh4eugqzmh8SmVCjQpqHFjZ8dO4AjdUV/4PqH2g7TXfhf/9M9hNq6AO8+AdY+ADnOtxhG9fKTGjfqOeoozi8lx5wze0PA2rPkd3oYFtD1yJwDiriCjyJC56st4Zt1D5rXfJ2PeGUmIWqnESlhLQUQuFJHNIrJNRA4biEdEJojIEyLynohsEJHPJio2NT7sat91+PAWoSA8+a/4A+W0rd7DhE99koqf/pSCq6/GqjqJ9t35NC3fzY7Lr6Pp375AqKsrKbErlSgJaSmIiAO4EzgfaADeEpHlxpi6qN1uA+qMMR8XkRJgs4g8aIzRKiQqJuo76jl38rmDV751L+xbi3fHB7Gymyj9yldwFhQw4WMfBcCEw/S9+xLtP7iZlqeeo2vNOir++7/IPuusJHwCpeIvUS2FM4BtxpgdkS/5h4Ch3TsMkCv2U0U5wEEgfqN+qXGlvbed1t5WaidE3WTuaIJ//Cfd1gK6/7mF4ltvxVlQMOh9YllknPohSv/rTmrOa8YKd7H7hhtpuuMOQl3dCf4USsVfopJCJbAnarkhsi7ar4BZQCOwDviiMYcPPSgiN4vIGhFZ09ysvUPUyOxst28yD7p89Pd/xwT62L/agauykoLPXHPkA5xwAZkf/RdqF2+h8BMfpO1/H2bnJZfQ/YaOKaXGlkQlheHGFBjapeMjwLtABXAy8CsRyTvsTcbcbYyZb4yZX1JSEus41RhV31EPRPU82vYCbHiU9oxL6N22k5IvfQkr8gT6EZ13B1bVPMoKnqH67l+A08Hu66+n4QtfpHfbtjh/AqUSI1FJoQGIHtKxCrtFEO2zwN+MbRuwE4hNZZokefTRRxERNm3adFzHeeaZZ5gxYwbTpk3jhz8cfjynkewznu3q2IVTnFTmVkKgB576CuG8qTQ/vQXPvHnkLbno6AdxZsCn7oegn6ztv2DK3/5K8ec+R/eqVez4+MXs/drX6Nu9O/4fRqk4SlRSeAuYLiK1IuIGrgSWD9lnN/BhABEpA2YAOxIUX1xEF9k5Vv0Fc55++mnq6upYtmwZdXV1o95nvKvvqKcqt8quFfD2A9C6k4O95xPc76Xsa19FrBH+UyieDkt+ArtewXrnt5R84fNMfeF5im68gc5nn2P7RUto+o9vE2gc+ptHqfSQkKRgjAkCtwN/BzYCDxtjNojIrSJya2S37wNnicg64AXg68aYA4mILx76i+zcd999LFu27JiPE10wx+12DxTMGe0+493O9p2H7ifseZOgexItf3menPM+TNbpp4/uYCdfA3M/Cf/4L9jzFs6CAkr/7d+Y+uzfKbjqKtofe4ztH7mQvV/+Ml0vvYQJan8JlT4S9vCaMWYFsGLIurui5huBC2J5zh+t/hGbDh7fpZuhZhbO5OtnfP2o+8WqyM5ICuZoUZ33FwqH2N2xm3Mqz7FX7F9Pc10B4d5WSr/8ldEfUAQ+9j/Q8Bb89Qa45RXIzMdVWkr5//0WRTd8lpbf3U/Hk0/SseJpHCXFTPjYx5nwiUvwzJgR2w+nVIzpE81xEqsiOyMpmKNFdd7fPt8++sJ99k3mQA+9O3fS9k4pBVdeRcaUYcZBGgnPBPjk7+D+C+Gxz8Gn/wSRS1CuigrK/++3KPvaV+l86SXaH3+cg3/8Iwfvv5+MWbPI+8hHyP3wubinTdP/TyrljOmkMJJf9PEQyyI7IymYo0V13l//QHg1eTXQvIm27ZmIZVF8+23Hd+BJp8MF/wnPfANe+wWc86VBm8XtJu/888k7/3yCra10PLWC9uXLaf75z2n++c9xTZ5M7rnnknPuh8g69VTEOab/Oao0oX8L4yCWRXZGUjBHi+q8v10duwComVADG5+mt9VJxtQanIWFx3/wM2+FPavtIbcrT4PaxcPu5iwooPAz11D4mWsI7N9P18qVdL7wD1offJCDv/89jvx8ss86i6yFC8heuBB3VdXxx6bUMdCkEAexLLLjdDqPWDBHi+qMzK72XeS4cijyFGH2rcff5ibnrHmxObgIXPxL2L8BHrkBbnkZ8t6/leYqK6PgyispuPJKQl3ddK96hc5//IPu11+nI1ITw1VVRfbCBWQtWEDWaafhLCvTS00qIWS469HpYv78+WbNmjWD1m3cuJFZs2YlKaKxYyz9Od787M109nWy7GPLCPzqQrb9qp6yb/47hUuXxu4kzZvh7g9B+Vy47klwukd9CGMMfdu30/3Gm3S/8Tq+1W8R7ugAwFFSTOa8E8mcNxfP3HlkzpuLIz8/dvGrcUVE3jbGzB9um7YU1Ji3q2MXp5adCsbQu3kLkEHGjBg/F1kyAy75pd1aeO7bcNHoHyAUETKmTSNj2jQKP3MNJhTCX7eRnvfew79uHT3r1tH1j38M7O+cOJGM2hrcNbW4p0zBXVtDRm0tzvLykT93odQQmhTUmNYT7KGpu8m+ydzZhN/bC2TgmRmHrqFzPwl73oI3f2PfhJ77yeM6nDgcZM6bS+a8uQPrQp2d+DdsoGfdOnq3bqVv5y7aH3+ccHfU4HwuF66SEpxlZTjLynCVleIsLcNZUoyVl4cjbwKO/Ak48vJw5OUh7tG3atTYpUlBjWm7O+xhJ2ryamD/BnpbnThLCnFMmBCfE17wfWj8Jzz+eSg+AcpjdO8iwpGbS/aCBWQvWDCwzhhDsLmZvp276Nu5g8DevQT27ye430vvpk10vfwyxuc74jHF48HyeJDMTKzMzEPzGRmI2424XIdebnuK5UAcFjickakDsRzgsOxWiuUAS+x1loVYErXOArEOzfcfy7Jf4nCAWIjTcWh5YB+HfSyHA0QO7TsQw+DpwLaBeO1t4nTan8Pl0ns1Q2hSUGPaoJ5HdU/jb3PhOTmO90ocLrj8frjnw/DAxXDdE/Z9hjgSEVylpbhKS8k+8/DqcMYYwl1dBA8cINzRQaijg1BbO6GO9shyJ6bXT7jHT9jfg/H1EPb7CXV3QVsQEwgMfvX1YcJhCIUwoZA9jSyno+ikN5AkLMvuRGAJIv0JKzLviCQmiUpATgficEbmnXaycjoQp8tOQJEXLueQJBtJuk5X5JgCRKYi9mz/MVwuJPJ+nE4yamvJmDYt5n8emhTUmNY/Ourk3MmE96ylr9NF7uz4fkmTVwHXPwkPfNx+Xbc85i2G0RARHLm5OHJz43oeY4xdzzoUsudDIQiH7YTRPzVm0LpB2/v3D4UOHWdI0jFhA+HQ4PeHwva6YadhTDgEoUNTwiFMMJLs+oYku2AQjMGYMITN4fGacCSGIccNhg5NAwHCPT57PhiMvAIQCB46b9Q5j7UGeNG/3ETpV47hifyj0KSgxrRd7bsoyyojy5VFz6b1YMAzMwGD7xZNtVsJD3w80mJIbmJIBOn/dWtZw46Vr4ZnQnYiIZI07RwRSUjG2Nv7AhCMSibBII4hBaFiRZOCGtN2deyyLx0Fe+nduReYQEaixh8qmmq3GH7/sUiL4YkxnxjU6InDYV9uShHab02NWcYYOylEhrfwtzkQjxv35MmJC6Jwip0YXNl2Ymham7hzK3UMNCnEUayK7NTU1DBv3jxOPvlk5s8f9nkTLbIzjIP+g3T2dUb1PHLhmVqb+F9l0YnhDxdD/euJPb9So6BJIY5iUWSn38qVK3n33XcZ+gQ3aJGdI+m/yVwzocYe3qLdRcacE5MTTGGtnRg8+fD7JfDcdyDYm5xYlHofmhTiJFZFdkZCi+wMr787anVeNcGt7xLus/Akc+iOwlq49RU45Vp49ef2sBj71iUvHqWGMaZvNO/77/+md2Nsi+xkzJpJ+Te/edT9YlVkB+xeHRdccAEiwi233DJQp6GfFtkZ3q6OXbgsFxVZE/Ft3gK4Yj+8xWhl5MLF/w9mfhQev91ODB/6Jpz9RfvhrnRhDPjbobvZfnV5wXcAejujXl3Q2wF9XXarqP8V6oVgnz0NB8Ec6u6JCdlTwO6kb0X13bewuzUN7c9vDfOKXm8//HZo3gLLCZbLfq7E4Y68IusGnS96PnL+Yc8XdQ7LETm+M2redWi5/5wD53dFzmsNfGz6+2+JDI7Vch7aP6sIsoti/r92TCeFZIpVkR2AV199lYqKCrxeL+effz4zZ85k8eJDQzRrkZ3hNXU1MTF7Ig5fC737ewAXGSeckOywbCd8BD73Bjz1JXjhu7DlGbjwB1BxauSLKMlCAWjbDW31keluaNtjT9sb7EQQOsLlL3FARg5k5NlJ0J0NTg9kRaYOd2Qa9UXZ/8Xa/2UORHfLtOfDUfNRUxOO2h4+tC4cGpxoBpbD9ucLB+xpoAdCfYfWDXvsI5wr+pjhkH2ucMhOdsR5sNGz/xXO/27MDzumk8JIftHHQyyL7AADBXNKS0u59NJLWb169aCkoEV2huf1eSnNKoX96/G3uXBNLMGRk53ssA7JLoLLH4B1j8CKr8A950LZPDh1KZx4OWTGpx/6ID1tcGArHNgSeUXmW3dGvtgixAETKiG/GmoXQU4pZJdAdinkRKbZxXYicGWmRmJLtnDY/jMc+goF7CQ0dH5QwuPQfDgYSWDBQ4ksHLSHUYmDMZ0UkiWWRXa6u7sJh8Pk5ubS3d3Ns88+y7e//e1B+2iRneE19zQzt3iunRRaXXjOmJ3skA4nYieA6efD+kfgnT/A01+FZ/8vzL7EThDVZw+U+jwmxtiXdw5uh+ZN9jDf/dPOpkP7WS772YrSmTDr41A0DQqqIX8y5FbYl1fUyFkWWG4gvQYc1P/LcRDLIjv79+/n0ksvBSAYDHL11Vdz4YUXAlpk5/0YY+yWQmYp4W1rCXQ5mTAnhR8cy8yH02+yX43vwj//CGv/Auseti+1FNTaX9iFUyLTqfalmaDffgX8h+a7D9iXfVp3QWvk8k+w59C5XNn2UN9TPmRPi0+wp/nV+sWvNCnEw4svvhizY02ZMoX33ntv2G0rIlW6wE4QS5Ysidl5011HXwe9oV5Ks0rxb3wYSNDwFrFQcbL9Ov/7sOkpaHoXDu6wL+1sfda+3HA0GXn2r/zi6XYrJL/a7v1UMhPyKo+v5aHGNE0Kakxq9jUDUJpRSO/ORiA3+T2PRsudZV9aOvHyQ+vCIejYCy3b7Rukzgy7JeHy2FOnx74XkVmg1/XVMdGkoMYkr88LQEnAj7/Vwsry4KocAzffLYd9jT8/gUN1qHFF25BqTPL22EmhtPMAva0uMqZN0W66So2AJgU1JvVfPipuqcff7sIz96QkR6RUetCkoMYkr89LnjsPx5a1mKCQkczhLZRKI5oU1JjU/+Caf8tWII16HimVZJoU1JjU3NNMqTuf3n0+ECFj+vRkh6RUWtCkoMYkr89LiTjwtzlxV5VheTzJDkmptKBJIY5iVWTnhhtuoLS0lLlzBxecH2lhnfFWgCcUDnGg5wClfX12YZ3Z4/vpbqVGQ5NCHMWqyM7111/PM888M2jdSAvrjMcCPK29rYRMiPLWNgI+JxlztOeRUiOlSSFOYllkZ/HixRQWFg5aN9LCOuOxAE//g2sTd7cB4Jk5I4nRKJVexvQTza88vIUDe7piesziSTksuuLoQ9bGssjOcEZaWGc8FuDpTwqFe9oA0m94C6WSKGFJQUQuBH4BOIB7jTGHXdwWkQ8CPwdcwAFjzAcSFV+sxbLIznBGWlhnPBbg6U8Kmfu6CGbl4iwtSXJESqWPhCQFEXEAdwLnAw3AWyKy3BhTF7VPPvBr4EJjzG4RKT3e847kF308xLrIznBGWlhnPBbgae5pxsLC0WGQsvwxnwSViqVEtRTOALYZY3YAiMhDwCVA9B3Pq4G/GWN2AxhjvAmKLeZiWWTnSEZaWGc8FuDx+rwUufMIdneTUVuW7HCUSiuJutFcCeyJWm6IrIt2AlAgIi+KyNsisnS4A4nIzSKyRkTWNDc3xync47Ns2TKeeOIJampqBl4bN2485i/jq666ioULF7J582aqqqq47777cDqdA4V1Zs2axRVXXDFQWGfJkiU0NjYCvO9+Y5XX56XEkUXA58BVNenob1BKDUhUS2G49vvQi91O4DTgw0Am8LqIvGGM2TLoTcbcDdwNMH/+/DhXxj42sSyyAxyx99KRCutEF995v/3GqmZfM1N8FiZk4arWJ5mVGo1EtRQagOifbFVA4zD7PGOM6TbGHABeBrSDuRo1r8/LpNYAAK6aaUmORqn0kqik8BYwXURqRcQNXAksH7LP48AiEXGKSBZwJrAxQfGpMaIv1EdrbysTD9g1iV2VQ69SKqXeT0IuHxljgiJyO/B37C6pvzPGbBCRWyPb7zLGbBSRZ4C1QBi72+r6Yzyf9jg5DsN1Y00XB3oOAFB8wAeAa4z3tFIq1kaVFERkPrDWGDOCyuGDGWNWACuGrLtryPJPgJ+M9tjRPB4PLS0tFBUVaWI4BsYYWlpa8KTpAHL9zyjkHezBynBi5eUlOSKl0suIk4KITAReA24A/hS3iI5TVVUVDQ0NpGrPpHTg8XioqqpKdhjHZODBtdY+XEUF+sNAqVEaTUvhOuAB4CZSOCm4XC5qa2uTHYZKkuYe+8eAs8vCVatPMis1WqO50Xwt8O+AW0SmxikepY6L1+fFJU7C3Q69yazUMRhRUhCRDwGbIl1F7wdujGtUSh0jr8/LpFAm4YCFa7K2GJUarZG2FG4E7ovM/y9wuYjosNsq5TT7mpnaYf/VdNXq6KhKjdZRv9gjA9UtAJ4GMMZ0AG8A4+cRWZU2vD1eJreGAHBNmpzkaJRKP0e90WyMaQOmDVl3bbwCUup4eH1eJh60n2Z26jMKSo3amC6yo8aX7kA33YFuilrCiENwFhcnOySl0s5IbzQ/LyI6DpFKac0+uztqXmsfzsIsxNLbXkqN1kj/1XwN+B8RuT/yEJtSKaf/wbWsDoO7tCjJ0SiVnkaUFIwx7xhjzgWeBJ4Rke+ISGZ8Q1NqdLw9dlJwdFk4J5YnORql0tOI29dijxewGfgN8Hlgq4joDWeVMpp9zbiCBvwOXJOqkx2OUmlppPcUVgF7gf/Brph2PfBB4AwRuTtewSk1Gl6fl0mddt8JV+2MJEejVHoaae+jW4EN5vAxlT8vIlrzQKUEr8/L1A4HwPtWXFvX0M7zG/fzr+dN1wHzlBpiREkhuq6BiDiMMaGozR+NeVRKHYPmnmZObbN/txxp3KNgKMxX/vIuW/Z3sWBKEQun6g1ppaIdS5+9uyOV0RCRxcaYHTGOSalj4vV5mdgaAAFXWemw+zzydgNb9nfhcgj3rdK/ukoNdSxJ4dvAfSLyR+D0GMej1DExxtDsa6aoNYBzggdxuQ7bp7s3yM+e28Kpk/O59QNTeWGTlx3NXUmIVqnUdSxJ4fvYvZAM8HBsw1Hq2LT3ttMX7iOvPYSreMKw+9zzyg68nb1866OzuXZhNS7L4v5XdyU2UKVS3Eh7H30navFrxpg7gP8DfGf4dyiVWP3PKGR2Cq7ywy8deTv8/PalHXx03kROqy6gNNfDxSdX8MjbDbT5Rl1dVqkxa6Qthe+IyI9E5B7sYbMLjDHdwC1xjE2pEfP6vFhhg6PbwlU16bDtP3tuC8FwmK9deKir6o3n1NITCPHn1bsTGapSKW2kScEAfuDvwCTgNRE5aUgvJKWSptnXTEEniBFc1YMLA27a18HDa/Zw7YIaqouy2fFuM8/fX8eMslzOnlbEH16rJxAKJylypVLLSJPCJmPMd4wxjxhjvglcgv0gm1IpwevzUtJhz7umzBq07QcrNpGT4eTz506j40APz/++js1v7mP3hhZuOmcK+zr8rFjXlISolUo9I00KB0TktP4FY8wWQKuiq5Th9Xmp6a+4FjXExStbm3lpSzOfP3c6+ZkuXnjAftYyM9fFhpf38oETSphSks29r+zk8GczlRp/RpoUvgD8SUT+JCJfF5EHgZ1xjEupUfH2eJnUZs+7JtoD+YbChv96aiNVBZksPaua9/6xh8atbSy6YjpzFlWya30LXa1+bjynlnV723lrV2vyPoBSKWKko6S+B5wMLIusWglcFaeYlBq1Zl8z5W1BHNlOrEx7AN/H/rmXTfs6+fqFM+ny9vDGYzuoPamYmQsnMvucCgTY+GoTl51SRX6Wi3tf0YfZlBrxcwrGmF5jzFPGmB8ZY+6N9D5SKiV4fV6K20K4inIH1j1bt49JhZlcNLuM5++vw53p4IPXzEREyC30UD23iLpVjbgdwmfOrOa5jfupb9G/1mp809JUKu0Fw0FaelrI6wBXVHGduqYOTqzKZ81Tuziwp4sPXjOTrDz3wPY5iyvxdfSx670DLF1YjdMSfZhNjXuaFFTaO+g/SNiE7AfXKuyB8Np7Auw52MNsVwbv/L2emWdNZMrJg/tGTJ5TRE5hButf3ktpnoePn1TBw2v20N0bTMbHUColHDUpiEjW0PrMIjJZRIYfhlKpBPP6vOT5wAoJrupaADY1deAy4H67lZxCD4suP3wobcsS5pxTScOmVtr2+/jkqVX4+kK8saMl0R9BqZQxkpZCAPibiGRHrbsX0FrNKiV4fV5K2u15V+1MwL50dIbfSV97Hx++bhbuzOFHiZ919kQsS9iwqpHTqgvwuCxe2XogUaErlXKOmhSMMQHgUeDTYLcSgBJjzJo4x6bUiDT7minuiNRRqLFbBHWNHUwxTspq86g8oeCI782ekEHtycVseq0JJ3BGbRGvbG1ORNhKpaSR3lO4F/hsZH4pcH98wlFq9Lw9Xsr6WwqR4jp1je2UBIXS6ryjvn/O4kr83QG2v9PM4unFbG/uprGtJ54hK5WyRvqcwiYAETkB+/mEP8YzKKVGw+vzUtUOltvCysujLxjmQKMPRxhKJ+ce9f1VJxQwoTSTDa/s5ZzpxQCs0ktIapwaTe+j+7BbDGuNMfrop0oZ+7r3MbEtjKswCxFhe3MXRQF7W8kIkoJYwpxFlTRta6c4KJTkZvDKNk0KanwaTVJ4GDgJOzkolTKauvZS3B7GVWLfO6hr7KAsZOFwWRSUZ43oGDMXluNwWtStamLRtGJe3XaAcFjHQlLjz2ieaPYZYyYYY54/lhOJyIUisllEtonIN95nv9NFJCQinzqW86jxJWzCNHXvI69DcE0sB+yeRxUhi+JJOViOkf0Vz8xxM/W0Eja/0cTZtYUc7O6jrqkjnqErlZIS8vCaiDiAO4GLgNnAVSIy+wj7/Qi7boNSR3XQfxBHTx+uPsE1aTIAdXvbKQ1blI3gJnO0GWeW0+cPMc3Y9Z21a6oajxL1RPMZwDZjzA5jTB/wEHZNhqE+D/wV8CYoLpXmGrsaKe7veVRzAsYYGvd04gxDSfXR7ydEq5iej9Nt0b6zk5nluazapl1T1fiTqKRQCeyJWm6IrBsQeUL6UuCu9zuQiNwsImtEZE1zs/6jHe8auxspaY88ozB1No3tfrJ9dhW10smjayk4XQ6qZhRQv/4A50wt4q1drfT0aXFBNb4kKinIMOuG3sX7OfD1o5X4NMbcbYyZb4yZX1KidX7Gu6aupoGKa86qydQ1dlAetLBcFvkjvMkcrXpuER0H/JxebHdtXb3rYIwjViq1JSopNGDXdu5XBTQO2Wc+8JCI7AI+BfxaRD6RkOhU2mrsaqSiHcQBzuLiSM8jsW8yW8P9Fnl/k+fYo6wWdYRxOyxW6dPNapwZfkCY2HsLmC4itcBe4Erg6ugdjDG1/fMi8nvgSWPMYwmKT6Wppu4mFrcZnPmZiGVR19jG7LCD8prRXTrql1ecSUF5Fo2bDjK/pkBvNqtxJyEtBWNMELgdu1fRRuBhY8wGEblVRG5NRAxqbGrs2ktZawh3mf2MQsPuTpxmZE8yH0n13CL2bm3jnNoiNu3rxNvpj1W4SqW8RLUUMMasAFYMWTfsTWVjzPWJiEmlv6auRvLbBddJFXT4A3CwD3BTMsruqNEmzy3i3ef3MMdhF+R5ddsBLj2lKkYRK5XatMiOSlsdfR2Yzm7cvYK7diqbmjopC1qIyyK/bPQ3mftVTM3HleHANPZQmO3WS0hqXNGkoNJWU1cT5ZFRuNzT51LX2E55SCiqOrabzP0cLouqmQXs2XCQs6cWsWrrAYzRIS/U+KBJQaWtxq5GytoizyicMI+6ve2UhS0qao/90lG/6rlFdB70s7A4D29nL1v2dx33MZVKB5oUVNpq7G6krL+lMGkSu+s7cJqR1VA4mv6uqZV+u8WhhXfUeKFJQaWtpq4mKloNjhwnoQwPPfvswjiloxzeYji5hR4KK7Jp3d7B1JJsva+gxg1NCiptNXY3MqnV4C7JY3tzF8UBQVxCfumx32SOVj23iKZtbSyuLeLNnS30BnXICzX2aVJQaaupYw8lbQZ3Rak9vEXIIr8iBzmOm8zRqucUEQ4ZTsnIxB8I81zd/pgcV6lUpklBpS1v215yusA1uYa6hnZKQ8KkqRNidvzyaRNweRzkHAxQU5TFPa/s1F5IaszTpKDSkj/ox9XcgSC4p85k1852nAhlxzi8xXAcDotJswrZU3eQG86u4b09bayp10q0amzTpKDSUlN3E2Wtke6oM06io6kbGFlN5tGonltEV2svH64oJD/LxT0v74jp8ZVKNZoUVFpq6mqirM2eP1g8mTyfgRjeZO43ebbdNXX/5jY+c2Y1z23cz84D3TE9h1KpRJOCSkuN3Y2UtxpwC5t8FmUhi9yJ2TG7ydwvpyCDoqoc6te3sPSsalyWxe9W7YzpOZRKJZoUVFpq7GqkvM2QUZRFXWMHpSFh8tT8uJyrem4R+7a3k2c5uOTkCv7y9h5au/vici6lkk2TgkpLTZ0NVLSCu6yIHdvbcCJUTIndTeZo0+eXYYzhjce2c9OiKfgDYR58sz4u51Iq2TQpqLTU1LaLonaDa1Il7Y32Nf7R1mQeqeKqHE46bzIbXmkkuz3I4hNKeOD1en2YTY1JmhRUWupp2oszJEj1VJztAYxTmFCSGbfznfHxWiaUZLLyjxu5cUE1zZ29LH93aEVZpdKfJgWVdoLhIA5vOwDNJdMpDVpklmbG/CZzNJfbwblLZ9JxwI+1vp2Z5bnct0ofZlNjjyYFlXa8Pi8lkWcUNmVPpjgkTIzhQ2tHUjG9gLkfqGTtygaWnjCRTfs6daA8NeZoUlBpp7+OgrFgY3sGboSaOPU8GmrhpVPJKcjAvNlCeU4G97yiD7OpsUWTgko7Td12xTUr38X+hsiTzJNi+yTzkbg9Tj70mZm07fdxbW4+r2w9wN837EvIuZVKBE0KKu00djVS2mbIKJmAv9mPESicmJ2w80+eXcTMsyYimzs4uyiXW//0Nne9tF3vL6gxQZOCSjtN7TspbwVHeRm5foM1wYXDldi/ymd/chqZuW4+2pPBJyeX8D9PbeLf/rJWu6mqtOdMdgBKjVZL0zaye6GzuJLSgxYFlTkJj8GT7eKD18zk6d+spbYRvkAm3SsP8NM3X+a0eaWUV+XiznTicFo4nBZOl4Uj8srIcpKZ48aT7cRy6O8ylVo0Kai0E2xoAmBXzhRyW4SaGNZQGI3aE4u59r/OomVvF637fKyta2bL1lbqVu9n+xsjK8iTkeXEk+MiM8eFJ8cdNW9PM3PcZGS7yMhy2vtmJb5VpMYXTQoqrRhjcHg7ANhgqskGqqbkJy2e3EIPuYUeaubBKedPZm1DG//yhzUEfEFuWljLJSdOxGNZhIJhgoEwob4wfl8Af1cAf3eAns4A/q4+eroCdB7007y7k56uPsLBI9+fcEZaG+5MJy6PE7fHgSvDgdvjxOVx4HI7cLotnG4HDpeFKzJ1uqyBlovDJVgOe95yCg6HheUQLIcg1qFlcQiW2FMREInfsyAqNWhSUGmlxd9CYWsYgIbuHGZgD0ORKk6syufx287ha39dy49f2cZv3trFdQtr+OzZNZTmZIzoGMYYAr0h/F2RpOEL0OsL0OcL4vcF6fUF7eWeIAF/iD5/iJ7OPgK99nygN0QoEI7L5xNLEAs7UViRRGENmZdDCUQsIHp5YJ/D1x9ajiSfI2xDBAH6/yNW/2xkX6LfF9knMh+930DMUcuDj31o//4FGZhGrYuKSawh5xv6mfvjFRn48zn0WQf9SR+aGxJr/75FlTmUVsf++RxNCiqtNHU1Ud5mCGVbhDsNYY9FZo472WENUj7Bwx9uOIO1DW38euV27nxxG/eu2sGVp0/mXxZPoTL//YfjEBHcHiduj5O84mMbusOEDcGg3TIJ9NlJIhgIEQoaQsEwoWCYcPR8yEReYUzY4O8L0ekL4OsN4u8L0dMXwt8XorcvhL8vTDBkv0KhMMGgIRgyhMNhwsZgwvb5jQHCHOqVNTAFicwOfG9jr4tetrC/fAcvH3ofQ7ZHT6OPgxnufVGvodvN4H2jRW8fbl30Zxm0PQ7yTy3imptPivlxNSmotNLY3WhXXCvMojgoZFbFb7yj43ViVT53XXsa27xd3PXSdv70Rj1/eqOeRdOLuWBOOefNKqMkd2Sth9ESS3C57UtJHlyDtnX4AzQc7KGh1cfe7h4a23rY39GLt9OPt7MXb0cvXb3BIx7b7bDIynCQ6XKQmWVPs9xOPC4HLoeF0xJ76hCclr1sWYIldgvDiroM1f/reGhvXmMMBggbQ9hA2ETWGTD0TxlYZmDZ3r//vfbBot4Tme8/nn3s6GUzKJ5DhxiyfiDQofGYqLgiy+HIcSPnkqhzm0iwR+zO3H+c0KGT9/85XDYpPn93NCmotNLUsYdpbRCaUkxRWCiPQ/M51qaV5vDTy0/iS+efwB9e28WK9U2s/Ns6vinrOHVyARfMLuOCOeXUFsfmWQt/IMTeth52H/TRcNDH7shrTyQRdPgHf+FnOC3K8jyU5mYwqzyPxdMzKM3LoCQng/wsNxMyXeRnuZiQab88LkdM4lSpSZOCSiv79m3izE7YO2EGFsK06QXJDmnEKvMz+fcls/jGRTPZtK+TZzfs59m6ffzg6U384OlN5HmcTCrMYnJhFpMKs5hUkElVYRbZbifBcJhQ2L5MEwwbQuEw7T0B9rX3sr/Tj7fDz74OP/s7ejnQ1Tvol3eG0xo43mnVBVQVZFJVkBWZZlKY7dYbyGqAJgWVVnz12wCod9dCkLRoKQwlIsyamMesiXl88bzp7DnoY+VmL1v3d7H7oI/N+zt5YZOXvuDIbhYXZrspy/NQlpfBnIkTKJ/gobrITi6TC7MozsnAiuMIsmps0aSg0kqw0e7/38hE8i3iWkMhUSYVZrF0Yc2gdeGwwdvZy55WH33BMA5LcFoSmVo4LCEv00lJbgYZTr2co2JHk4JKK87mLgD84QlYBe641lBIJssSyid4KJ/gSXYoapzRRyNV2ujs6yS/NUTADYVhF/mViRsET6nxImFJQUQuFJHNIrJNRL4xzPZrRGRt5PWaiMS+A65Ka3YdBegsLsWDUDM1fW4yK5UuEpIURMQB3AlcBMwGrhKR2UN22wl8wBhzIvB94O5ExKbSR1OX/YxCe+EUAKZOz09uQEqNQYlqKZwBbDPG7DDG9AEPAZdE72CMec0Y0xpZfAOoSlBsKk00tmyhtB1as6dggKKqxBTWUWo8SVRSqAT2RC03RNYdyY3A08NtEJGbRWSNiKxpbm6OYYgq1bXuWIcrBG2uSYSy7ad1lVKxlaikMFwXkWGf6xaRD2Enha8Pt90Yc7cxZr4xZn5JSUkMQ1Sprqd+JwB9jhIyS9O/K6pSqShRXVIbgElRy1VA49CdRORE4F7gImNMS4JiU2ki0OQl4MzELZmUT9ZLR0rFQ6JaCm8B00WkVkTcwJXA8ugdRGQy8DfgWmPMlgTFpdKEL+CDA9105lYAcMKMwiRHpNTYlJCWgjEmKCK3A38HHMDvjDEbROTWyPa7gG8DRcCvI+OwBI0x8xMRn0p9G1o2UNYK7UV2g3PS1PzkBqTUGJWwJ5qNMSuAFUPW3RU1fxNwU6LiUenlvX1vU91saKmuJeAUsvJSq4aCUmOFPtGs0sLmzS9S1QIHM6uxCnVUT6XiRZOCSnnGGPrWbSYsFiFnEQUVOryFUvGiSUGlvIbOBqrqe+nKKcMSi2q9n6BU3GhSUCnvXe8/mbXH0FY5FYCZM4uSHJFSY5cmBZXy6ratpHY/NBfOJCRQrJePlIobTQoq5bW9vRrLQKOrhnCuE8uhf22VihctsqNSmi/gI3d7K31ONx7Jp3T6hGSHpNSYpj+5VEqra6ljxh7D/uq5OBDOPFsHz1UqnjQpqJS2dvtKpjdCY/F8gg6YPEML6ygVT5oUVErbv/ofOENCh2cGnknZOPR+glJxpf/CVMoyxiCb9tKZOwmHeJh7enmyQ1JqzNOkoFLW3q69VO8O0lg1DwOceubEZIek1JinSUGlrPd2r2LGXkNzwUkEC1xk5uggeErFmyYFlbJ2v/YEFhMIuCupmqP1E5RKBE0KKmX1rttMS9EcAM5apF1RlUoETQoqJfmDfgp3+thXNpdetzBxcl6yQ1JqXNCkoFJS3f53mb7XQXveTHJqc7V+glIJoklBpaQtrz5MKGM6xsrg1AXa60ipRNGkoFJS+5q3aCmaS5gwJ5+mzycolSiaFFTKMcaQse0gzSVzCZZ6cLodyQ5JqXFDk4JKOY0dDVQ2l9GbUcyUk0qSHY5S44omBZVy6t78X0KeuQAs+sCkJEej1PiiSUGlHO+rL3CgaC4hl5/C4qxkh6PUuKJFdlRKMcYQ3NxK14QpZM3SYbKVSjRtKaiU8vx7yyg6OB3E4sxz9NKRUommSUGljJ5gD5t+8UP82XMJE2DuXL3JrFSiaVJQKeMvD/8bp20oZ3/pKTimFSCWPsWsVKJpUlApobFtF7n3r2LjrM/S57JYevNJyQ5JqXFJk4JKCU/88HpM5qfo8ZSy+Lo55ORlJDskpcYlTQoq6d56+2GqV0+kqeJssk4q4LTTdawjpZJFk4JKqmA4yMYf/5L62qsJunv0spFSSabPKaikeurez+PgGoJOJ5d8eSFOp45zpFQyaVJQSdPWuofeFW7ayk9g4uICamrykx2SUuOeXj5SSREI9fHYN77EgdKP4cho4NKrTk52SEoptKWgEqy7+yBP/X9fJbA2n768z2BZHXz6u5drZTWlUkTCkoKIXAj8AnAA9xpjfjhku0S2LwF8wPXGmHcSFZ+Kr3316/n7T36JtMyiM+8qKLZwsovTP/sBCvIzkx2eUioiIUlBRBzAncD5QAPwlogsN8bURe12ETA98joT+E1kqlJYOBQi4PfT1+fH19nO7s0b8O7YQee+Fvra/YR8QE8GQesk+jI+jSO7g8zsTXzwc1cyZdq5yQ5fKTVEoloKZwDbjDE7AETkIeASIDopXAL8wRhjgDdEJF9EJhpjmmIdzIPf+g4dXs03R3ekSzqCEcGIBTK0t1A2MG/wKk+YjN4tlE47yCVfvBG3S3sYKZWqEpUUKoE9UcsNHN4KGG6fSmBQUhCRm4GbI4tdIrL5GGMqBg4c43vTVfI/81dvSfQZk/+ZE08/8/hwPJ+5+kgbEpUUhvvJaY5hH4wxdwN3H3dAImuMMfOP9zjpRD/z+KCfeXyI12dOVJfUBiB6cPwqoPEY9lFKKRVHiUoKbwHTRaRWRNzAlcDyIfssB5aKbQHQHo/7CUoppY4sIZePjDFBEbkd+Dt2l9TfGWM2iMitke13ASuwu6Nuw+6S+tk4h3Xcl6DSkH7m8UE/8/gQl88sdmcfpZRSSoe5UEopFUWTglJKqQHjOimIyE9EZJOIrBWRR0UkP9kxxZuIXC4iG0QkLCJjugufiFwoIptFZJuIfCPZ8cSbiPxORLwisj7ZsSSCiEwSkZUisjHyd/qLyY4p3kTEIyKrReS9yGf+bqzPMa6TAvAcMNcYcyKwBfj3JMeTCOuBy4CXkx1IPEUNrXIRMBu4SkRmJzequPs9cGGyg0igIPAVY8wsYAFw2zj4f9wLnGuMOQk4Gbgw0lszZsZ1UjDGPGuMCUYW38B+NmJMM8ZsNMYc61Pg6WRgaBVjTB/QP7TKmGWMeRk4mOw4EsUY09Q/aKYxphPYiD0KwphlbF2RRVfkFdPeQuM6KQxxA/B0soNQMXOkYVPUGCQiNcApwJtJDiXuRMQhIu8CXuA5Y0xMP/OYr6cgIs8D5cNs+pYx5vHIPt/Cboo+mMjY4mUkn3kcGNGwKSr9iUgO8FfgX40xHcmOJ96MMSHg5Mg90EdFZK4xJmb3kcZ8UjDGnPd+20XkOuBjwIfNGHlo42ifeZzQYVPGARFxYSeEB40xf0t2PIlkjGkTkRex7yPFLCmM68tHkcI/XwcuNsb4kh2PiqmRDK2i0likMNd9wEZjzM+SHU8iiEhJfy9JEckEzgM2xfIc4zopAL8CcoHnRORdEbkr2QHFm4hcKiINwELgKRH5e7JjiodIB4L+oVU2Ag8bYzYkN6r4EpFlwOvADBFpEJEbkx1TnJ0NXAucG/n3+66ILEl2UHE2EVgpImuxf/g8Z4x5MpYn0GEulFJKDRjvLQWllFJRNCkopZQaoElBKaXUAE0KSimlBmhSUEopNUCTglJKqQGaFJRSSg3QpKDUMRCRKhH5dNTyb0Xk7GTGpFQsaFJQ6th8GDg1avlM7OHXlUprmhSUGiUROQf4GfCpyNAKs4AtxpiQiNREqvk9EKno94iIZIlItog8FamYtT66laFUKtGkoNQoGWNWYY87c4kx5mTs6m7PRO0yA7g7UtGvA/gc9kiWjcaYk4wxc4fsr1TK0KSg1LGZAfRXsPsIg7/k9xhjXo3M/wk4B1gHnCciPxKRRcaY9sSFqtTIaVJQapREpAhoN8YERCQLyDfGRNdqGDrKpDHGbAFOw04OPxCRbycoXKVGRZOCUqNXy6GCPR8CVg7ZPllEFkbmrwJWiUgF4DPG/An4KYNvUiuVMsZ85TWl4mATUCwi67Hr5H5vyPaNwHUi8ltgK/AbYBHwExEJAwHg/yQwXqVGTOspKHUcROQd4ExjTCCyXAM8GbmZrFTa0ZaCUsfBGKOXgdSYoi0FpZRSA/RGs1JKqQGaFJRSSg3QpKCUUmqAJgWllFIDNCkopZQaoElBKaXUAE0KSimlBvz/5lUgkGTOWEoAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "for t, s_xy, delta in zip(t_list, s_xy_list, deltas):\n",
-    "    plt.plot(t, s_xy, label=r\"$\\Delta = $\"+f\"{delta:0.1f}\")\n",
-    "    plt.xlabel(r'$t/$ps')\n",
-    "    plt.ylabel(r'$<\\sigma_xy>$')\n",
-    "plt.ylim((0.0,1.0))\n",
-    "plt.legend()"
+    "for i,n in enumerate(n_list):\n",
+    "    ratio = pump_ratios[i]\n",
+    "    label = r'$\\Gamma_\\uparrow = {}\\Gamma_\\downarrow$'.format(pump_ratios[i])\n",
+    "    plt.plot(t_list[i], n_list[i], label=label)\n",
+    "plt.xlabel(r'$t$ (ps)', fontsize=16)\n",
+    "plt.yticks(ticks=[0,0.05,0.1,0.15],fontsize=14)\n",
+    "plt.xticks(ticks=[0,250,500], labels=['0','1','2'], fontsize=14)\n",
+    "plt.ylabel(r'$n/N$', fontsize=16)\n",
+    "plt.ylim((0.0,0.15))\n",
+    "plt.legend(fontsize=16);"
    ]
   },
   {
@@ -572,9 +517,9 @@
    "hash": "3306e98808c0871e8a1685f50cc307ae5b4a4a013844b10634a4efe89132c3fe"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "oqupy",
    "language": "python",
-   "name": "python3"
+   "name": "oqupy"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
### Main changes
* Fixed an off-by-one error in `compute_dynamics_all` (the field equation of motion should not be evaluated until the second step)
* Added docstring for `compute_dynamics_with_field` in `contractions.py`
* New helper function `_get_propagators` in `contractions.py` (allows for sampling in the WithField case if `subdiv_limit` is set to None)
* Added tests in `tests/coverage/tempo/py_tempo_test.py` to cover `compute_dynamics_with_field` - let me know if these need extended
* Added test `tests/physics/example_G_test.py` based on the Dicke model (calculated independently using TEMPO release code). This tests both TEMPO and PT-TEMPO methods.
* Updated `index.rst` and `authors.rst` for the upcoming release
* Added a new tutorial for the mean-field code based on [FowlerWright2021][arXiv:2112.09003](http://arxiv.org/abs/2112.09003) using both TEMPO and PT-TEMPO

####  A few things I noticed when making these changes
*  Many helper functions in `contractions.py` remain without a docstring
* The `compute_dynamics...` methods have no progress bar
* The `description` string for objects derived from `BaseDynamics` is never used - perhaps it would be nice to set this automatically when generating dynamics with TEMPO or PT-TEMPO e.g. to record method used, computation time or system/environment information
* The version strings in `index.rst` and the tutorial need to be updated once the version number for this release is known

# Pull Request Check List

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [x] API code contributions include input checks (defensive code).
* [x] API code contributions include helpful error messages.
* [x] The documentation has been updated:
  - [x] docstring for all new functions/methods/classes/modules.
  - [x] consistent style of all docstrings.
  - [x] for new modules: `/docs/pages/modules.rst` has been updated.
  - [x] for api contributions: `/docs/pages/api.rst` has been updated.
  - [x] for api contributions: tutorials and examples have been updated.
