### PR TITLE
bugfix #83 mean-field control

### DIFF
--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -359,16 +359,17 @@ def compute_dynamics_with_field(
         # -- calculate time reached --
         t = start_time + step * dt
 
-        # -- apply pre measurement control --
+        # -- get pre & post measurement control list --
         controls_tuple_list = [prepare_controls(step, control)
                                for control in parsed_parameters_dict["control"]]
 
-        for (current_node, current_edges), \
-        (pre_measurement_control, post_measurement_control) in \
-        zip(nodes_and_edges_list, controls_tuple_list):
-            if pre_measurement_control is not None:
-                current_node, current_edges = _apply_system_superoperator(
-                        current_node, current_edges, pre_measurement_control)
+        # -- apply pre measurement control --
+        nodes_and_edges_list = [
+            _apply_system_superoperator(
+                current_node, current_edges, pre_measurement_control) \
+                for (current_node, current_edges), (pre_measurement_control,_) \
+                in zip(nodes_and_edges_list, controls_tuple_list)
+        ]
 
         if step == num_steps:
             break
@@ -398,12 +399,12 @@ def compute_dynamics_with_field(
         prog_bar.update(step)
 
         # -- apply post measurement control --
-        for (current_node, current_edges), \
-                (pre_measurement_control, post_measurement_control) in \
-            zip(nodes_and_edges_list, controls_tuple_list):
-            if post_measurement_control is not None:
-                current_node, current_edges = _apply_system_superoperator(
-                        current_node, current_edges, post_measurement_control)
+        nodes_and_edges_list = [
+            _apply_system_superoperator(
+                current_node, current_edges, post_measurement_control) \
+                for (current_node, current_edges), (_,post_measurement_control)\
+                in zip(nodes_and_edges_list, controls_tuple_list)
+        ]
 
         # -- propagate one time step --
         propagator_tuples_list = [propagators(step, field,
@@ -579,6 +580,8 @@ def _get_pt_mpos(process_tensors: List[BaseProcessTensor], step: int):
 
 def _apply_system_superoperator(current_node, current_edges, sup_op):
     """ToDo """
+    if sup_op is None:
+        return current_node, current_edges
     sup_op_node = tn.Node(sup_op.T)
     current_edges[-1] ^ sup_op_node[0]
     new_sys_edge = sup_op_node[1]

--- a/tests/coverage/contractions_test.py
+++ b/tests/coverage/contractions_test.py
@@ -18,7 +18,7 @@ Tests for the time_evovling_mpo.pt_tempo module.
 import pytest
 import numpy as np
 
-import oqupy as tempo
+import oqupy
 
 def test_compute_dynamics_with_field():
     start_time = 1
@@ -26,21 +26,21 @@ def test_compute_dynamics_with_field():
     dt = 0.2
     end_time = start_time + (num_steps-1) * dt
     initial_field = 0.5j
-    
-    system = tempo.TimeDependentSystemWithField(
-                lambda t, field: 1j * 0.2 * tempo.operators.sigma("y") * field)
+
+    system = oqupy.TimeDependentSystemWithField(
+                lambda t, field: 1j * 0.2 * oqupy.operators.sigma("y") * field)
     field_eom = lambda t, states, field: -1j*field -0.1j * np.matmul(
-                tempo.operators.sigma("y"), states[0]).trace().real
-    mean_field_system = tempo.MeanFieldSystem([system], field_eom)
-    correlations = tempo.PowerLawSD(alpha=3,
+                oqupy.operators.sigma("y"), states[0]).trace().real
+    mean_field_system = oqupy.MeanFieldSystem([system], field_eom)
+    correlations = oqupy.PowerLawSD(alpha=3,
                                 zeta=1,
                                 cutoff=1.0,
                                 cutoff_type='gaussian',
                                 temperature=0.0)
-    bath = tempo.Bath(0.5 * tempo.operators.sigma("x"), correlations)
-    tempo_parameters = tempo.TempoParameters(dt=dt, dkmax=20, epsrel=10**(-5))
-    
-    mean_field_dynamics = tempo.compute_dynamics_with_field(
+    bath = oqupy.Bath(0.5 * oqupy.operators.sigma("x"), correlations)
+    tempo_parameters = oqupy.TempoParameters(dt=dt, dkmax=20, epsrel=10**(-5))
+
+    mean_field_dynamics = oqupy.compute_dynamics_with_field(
             mean_field_system,
             initial_field,
             initial_state_list = [np.array([[0.5,-0.51j],[0,-.25]])],
@@ -48,29 +48,29 @@ def test_compute_dynamics_with_field():
             num_steps = num_steps,
             start_time = start_time
             )
-    
-    pt = tempo.pt_tempo_compute(bath=bath,
+
+    pt = oqupy.pt_tempo_compute(bath=bath,
                                       start_time=0.0,
                                       end_time=end_time,
                                       parameters=tempo_parameters)
-    assert isinstance(mean_field_dynamics, tempo.dynamics. MeanFieldDynamics) 
-    assert len(mean_field_dynamics.times) == 1 + num_steps 
-    assert np.isclose(np.min(mean_field_dynamics.times), start_time)  
-    assert type(mean_field_dynamics.fields[1]) == tempo.config.NpDtype 
-    assert np.isclose(mean_field_dynamics.fields[0], initial_field) 
+    assert isinstance(mean_field_dynamics, oqupy.dynamics. MeanFieldDynamics)
+    assert len(mean_field_dynamics.times) == 1 + num_steps
+    assert np.isclose(np.min(mean_field_dynamics.times), start_time)
+    assert type(mean_field_dynamics.fields[1]) == oqupy.config.NpDtype
+    assert np.isclose(mean_field_dynamics.fields[0], initial_field)
     # check correct type of dynamics returned
-    assert isinstance(mean_field_dynamics, tempo.dynamics.MeanFieldDynamics)
-    # initial time plus num_steps steps 
-    assert len(mean_field_dynamics.times) == 1 + num_steps 
+    assert isinstance(mean_field_dynamics, oqupy.dynamics.MeanFieldDynamics)
+    # initial time plus num_steps steps
+    assert len(mean_field_dynamics.times) == 1 + num_steps
     # check start_time used correctly
     assert np.isclose(np.min(mean_field_dynamics.times), start_time)
     # check complex type
-    assert type(mean_field_dynamics.fields[1]) == tempo.config.NpDtype
-    # check initial field recorded correctly 
-    assert np.isclose(mean_field_dynamics.fields[0], initial_field) 
-    
+    assert type(mean_field_dynamics.fields[1]) == oqupy.config.NpDtype
+    # check initial field recorded correctly
+    assert np.isclose(mean_field_dynamics.fields[0], initial_field)
+
     # Test subdiv_limit == None
-    mean_field_dynamics2 = tempo.compute_dynamics_with_field(
+    mean_field_dynamics2 = oqupy.compute_dynamics_with_field(
             mean_field_system,
             initial_field,
             initial_state_list = [np.array([[0.5,-0.51j],[0,-.25]])],
@@ -79,17 +79,17 @@ def test_compute_dynamics_with_field():
             start_time = start_time,
             subdiv_limit = None
             )
-    
+
     # input checks
     # No initial field / wrong type
     with pytest.raises(TypeError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
                 mean_field_system,
                 initial_state_list = [np.eye(2)],
                 dt = dt,
                 )
     with pytest.raises(TypeError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
             mean_field_system,
             None,
             initial_state_list=[np.eye(2)],
@@ -97,8 +97,8 @@ def test_compute_dynamics_with_field():
             )
     # Wrong system type
     with pytest.raises(AssertionError):
-        tempo.compute_dynamics_with_field(
-                tempo.TimeDependentSystem(lambda t: 0.5 * t * np.eye(2)),
+        oqupy.compute_dynamics_with_field(
+                oqupy.TimeDependentSystem(lambda t: 0.5 * t * np.eye(2)),
                 initial_field,
                 initial_state_list = [np.array([[0.5,-0.51j],[0,-.25]])],
                 dt = dt,
@@ -107,7 +107,7 @@ def test_compute_dynamics_with_field():
                 )
     # too many process tensors
     with pytest.raises(AssertionError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
                 mean_field_system,
                 initial_field,
                 initial_state_list = [np.array([[0.5,-0.51j],[0,-.25]])],
@@ -118,7 +118,7 @@ def test_compute_dynamics_with_field():
                 )
     # forget lists
     with pytest.raises(AssertionError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
                 mean_field_system,
                 initial_field,
                 initial_state_list = [np.array([[0.5,-0.51j],[0,-.25]])],
@@ -128,7 +128,7 @@ def test_compute_dynamics_with_field():
                 start_time = start_time
                 )
     with pytest.raises(AssertionError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
                 mean_field_system,
                 initial_field,
                 initial_state_list = np.array([[0.5,-0.51j],[0,-.25]]),
@@ -139,7 +139,7 @@ def test_compute_dynamics_with_field():
                 )
     #too many steps for process tensor
     with pytest.raises(AssertionError):
-        tempo.compute_dynamics_with_field(
+        oqupy.compute_dynamics_with_field(
                 mean_field_system,
                 initial_field,
                 initial_state_list = np.array([[0.5,-0.51j],[0,-.25]]),
@@ -148,3 +148,40 @@ def test_compute_dynamics_with_field():
                 num_steps = 2*num_steps,
                 start_time = start_time
                 )
+
+def test_mean_field_and_with_control():
+    sigma_z = oqupy.operators.sigma('z')
+    tempo_parameters = oqupy.TempoParameters(dt=0.2, dkmax=10, epsrel=10**(-2))
+    t0 = 0.0
+    tf = 1.0
+
+    H_MF = lambda t,a: 1.0*sigma_z
+    field_eom = lambda t,states,a: 1j
+    molecule = oqupy.TimeDependentSystemWithField(H_MF)
+    total_sys = oqupy.MeanFieldSystem([molecule], field_eom=field_eom)
+    correlations = oqupy.PowerLawSD(alpha=1,zeta=1,cutoff=1)
+    bath = oqupy.Bath(sigma_z, correlations)
+    pt = oqupy.pt_tempo_compute(bath=bath, start_time=t0, end_time=tf, parameters=tempo_parameters)
+    initial_field = 1.0
+    initial_state = .5*sigma_z
+
+    dynamics_1 = \
+        oqupy.compute_dynamics_with_field(
+            total_sys,
+            initial_field=initial_field,
+            initial_state_list=[initial_state],
+            start_time=t0,
+            process_tensor_list = [pt])
+    control=oqupy.Control(2)
+    control.add_single(1, oqupy.operators.left_super(sigma_z), post=False)
+    control.add_single(3, oqupy.operators.left_super(sigma_z), post=True)
+
+    dynamics_2 = \
+        oqupy.compute_dynamics_with_field(
+            total_sys,
+            initial_field=initial_field,
+            initial_state_list=[initial_state],
+            start_time=t0,
+            process_tensor_list=[pt],
+            control_list=[control],
+        )


### PR DESCRIPTION
fixes #83 

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
