### PR TITLE
Degeneracy checking for MF-TEMPO

### DIFF
--- a/docs/pages/tutorials/mf_tempo.rst
+++ b/docs/pages/tutorials/mf_tempo.rst
@@ -347,7 +347,7 @@ used to compute the dynamics for an ordinary ``System``:
                                      initial_field=initial_field,
                                      start_time=start_time,
                                      parameters=tempo_parameters,
-                                     unique=true)
+                                     unique=True)
     mean_field_dynamics = tempo_sys.compute(end_time=end_time)
 
 

--- a/docs/pages/tutorials/mf_tempo.rst
+++ b/docs/pages/tutorials/mf_tempo.rst
@@ -346,7 +346,8 @@ used to compute the dynamics for an ordinary ``System``:
                                      initial_state_list=initial_state_list,
                                      initial_field=initial_field,
                                      start_time=start_time,
-                                     parameters=tempo_parameters)
+                                     parameters=tempo_parameters,
+                                     unique=true)
     mean_field_dynamics = tempo_sys.compute(end_time=end_time)
 
 

--- a/examples/mean-field-multiple-systems.py
+++ b/examples/mean-field-multiple-systems.py
@@ -74,7 +74,8 @@ tempo_sys = oqupy.MeanFieldTempo(mean_field_system=mean_field_system,
                         parameters=tempo_parameters,
                         initial_state_list=initial_state_list,
                         initial_field=initial_field,
-                        start_time=0.0)
+                        start_time=0.0,
+                        unique=True)
 mean_field_dynamics_tempo = tempo_sys.compute(end_time=end_time)
 
 fig, axes = plt.subplots(2, figsize=(9,6), sharex=True)

--- a/examples/mean-field-tempo.py
+++ b/examples/mean-field-tempo.py
@@ -52,7 +52,8 @@ tempo_sys = oqupy.MeanFieldTempo(mean_field_system=mean_field_system,
                         initial_state_list=[initial_state],
                         initial_field=initial_field,
                         start_time=0.0,
-                        parameters=tempo_parameters)
+                        parameters=tempo_parameters,
+                        unique=True)
 mean_field_dynamics = tempo_sys.compute(end_time=end_time)
 system_dynamics = mean_field_dynamics.system_dynamics[0]
 

--- a/oqupy/backends/tempo_backend.py
+++ b/oqupy/backends/tempo_backend.py
@@ -24,7 +24,7 @@ from numpy import max as numpy_max
 from oqupy import operators
 from oqupy.config import TEMPO_BACKEND_CONFIG
 from oqupy.backends import node_array as na
-from oqupy.util import create_delta, check_isinstance
+from oqupy.util import create_delta
 
 class BaseTempoBackend:
     """

--- a/oqupy/backends/tempo_backend.py
+++ b/oqupy/backends/tempo_backend.py
@@ -24,7 +24,7 @@ from numpy import max as numpy_max
 from oqupy import operators
 from oqupy.config import TEMPO_BACKEND_CONFIG
 from oqupy.backends import node_array as na
-from oqupy.util import create_delta
+from oqupy.util import create_delta, check_isinstance
 
 class BaseTempoBackend:
     """
@@ -55,7 +55,7 @@ class BaseTempoBackend:
     west_degeneracy_map: Optional[ndarray]
         Array to invert the degeneracy in west direction
     dim: Optional[int]
-        Hilbert space dimension, only needed if unique is True
+        Hilbert space dimension, needed if unique is True
     """
     def __init__(
             self,
@@ -91,6 +91,13 @@ class BaseTempoBackend:
         self._north_degeneracy_map = north_degeneracy_map
         self._west_degeneracy_map = west_degeneracy_map
         self._dim = dim
+        if unique:
+            assert north_degeneracy_map is not None, "north_degeneracy_map "\
+                    "must be specified if unique."
+            assert west_degeneracy_map is not None, "west_degeneracy_map "\
+                    "must be specified if unique."
+            assert dim is not None, "dim "\
+                    "must be specified if unique."
 
     @property
     def step(self) -> int:

--- a/oqupy/backends/tempo_backend.py
+++ b/oqupy/backends/tempo_backend.py
@@ -395,10 +395,10 @@ class MeanFieldTempoBackend():
     unique: Optional[bool]
         Whether to use degeneracy checks.
     north_degeneracy_list: Optional[List[ndarray]]
-        List of arrays to invert the degeneracy in north direction for each 
+        List of arrays to invert the degeneracy in north direction for each
         system's environment.
     west_degeneracy_list: Optional[List[ndarray]]
-        List of arrays to invert the degeneracy in west direction for each 
+        List of arrays to invert the degeneracy in west direction for each
         system's environment.
     dim_list: Optional[List[int]]
         Hilbert space dimension of each system, needed if unique is True.

--- a/oqupy/backends/tempo_backend.py
+++ b/oqupy/backends/tempo_backend.py
@@ -392,6 +392,16 @@ class MeanFieldTempoBackend():
         are included. Applies to all systems.
     epsrel: float
         Maximal relative SVD truncation error. Applies to all systems.
+    unique: Optional[bool]
+        Whether to use degeneracy checks.
+    north_degeneracy_list: Optional[List[ndarray]]
+        List of arrays to invert the degeneracy in north direction for each 
+        system's environment.
+    west_degeneracy_list: Optional[List[ndarray]]
+        List of arrays to invert the degeneracy in west direction for each 
+        system's environment.
+    dim_list: Optional[List[int]]
+        Hilbert space dimension of each system, needed if unique is True.
     """
     def __init__(
             self,
@@ -409,7 +419,12 @@ class MeanFieldTempoBackend():
             sum_west_list: List[ndarray],
             dkmax: int,
             epsrel: float,
-            config: Dict):
+            config: Dict,
+            unique: Optional[bool] = False,
+            north_degeneracy_list: Optional[List[ndarray]] = None,
+            west_degeneracy_list: Optional[List[ndarray]] = None,
+            dim_list: Optional[List[ndarray]] = None,
+            ):
         """Create a MeanFieldTempoBackend object. """
         self._initial_state_list = initial_state_list
         self._initial_field = initial_field
@@ -419,6 +434,8 @@ class MeanFieldTempoBackend():
         self._state_list = initial_state_list
         self._step = None
         self._propagators_list = propagators_list
+        self._north_degeneracy_list = north_degeneracy_list
+        self._west_degeneracy_list = west_degeneracy_list
         # List of BaseTempoBackends use to calculate each system dynamics
         self._backend_list = [BaseTempoBackend(initial_state,
                          influence,
@@ -427,11 +444,18 @@ class MeanFieldTempoBackend():
                          sum_west,
                          dkmax,
                          epsrel,
-                         config)
+                         config,
+                         unique,
+                         north_degeneracy_map,
+                         west_degeneracy_map,
+                         dim)
                          for initial_state, influence, unitary_transform,
-                         sum_north, sum_west in zip(initial_state_list,
+                         sum_north, sum_west, north_degeneracy_map,
+                         west_degeneracy_map, dim in zip(initial_state_list,
                              influence_list, unitary_transform_list,
-                             sum_north_list, sum_west_list)]
+                             sum_north_list, sum_west_list,
+                             north_degeneracy_list, west_degeneracy_list,
+                             dim_list)]
 
     @property
     def step(self) -> int:

--- a/oqupy/bath.py
+++ b/oqupy/bath.py
@@ -83,12 +83,12 @@ class Bath(BaseAPIClass):
         # identify degeneracies in eigensystem of coupling operator
         tmp_coupling_comm = commutator(self._coupling_operator)
         tmp_coupling_acomm = acommutator(self._coupling_operator)
-        coupling_comm = tmp_coupling_comm.diagonal()
-        coupling_acomm = tmp_coupling_acomm.diagonal()
+        self._coupling_comm = tmp_coupling_comm.diagonal()
+        self._coupling_acomm = tmp_coupling_acomm.diagonal()
 
-        self._north_degeneracy_map = _row_degeneracy([coupling_comm,
-                                                      coupling_acomm])
-        self._west_degeneracy_map = _row_degeneracy([coupling_comm])
+        self._north_degeneracy_map = _row_degeneracy([self._coupling_comm,
+                                                      self._coupling_acomm])
+        self._west_degeneracy_map = _row_degeneracy([self._coupling_comm])
 
         # input check for correlations.
         if not isinstance(correlations, BaseCorrelations):
@@ -125,6 +125,18 @@ class Bath(BaseAPIClass):
     def correlations(self) -> BaseCorrelations:
         """The correlations of the bath. """
         return copy(self._correlations)
+
+    @property
+    def coupling_acomm(self) -> np.ndarray:
+        """Diagonal elements of the anti-commutator of the coupling
+        operator. """
+        return self._coupling_acomm.copy()
+
+    @property
+    def coupling_comm(self) -> np.ndarray:
+        """Diagonal elements of the commutator of the coupling
+        operator. """
+        return self._coupling_comm.copy()
 
     @property
     def north_degeneracy_map(self) -> np.ndarray:

--- a/oqupy/tempo.py
+++ b/oqupy/tempo.py
@@ -234,7 +234,7 @@ class Tempo(BaseAPIClass):
     unique: bool (default = False),
         Whether to use degeneracy checking. If True reduces dimension of
         bath tensors in case of degeneracies in sums ('west') and
-        sums,differences ('north') of bath coupling operator.
+        sums,differences ('north') of the bath coupling operator.
         See bath:north_degeneracy_map, bath:west_degeneracy_map.
     backend_config: dict (default = None)
         The configuration of the backend. If `backend_config` is
@@ -285,11 +285,6 @@ class Tempo(BaseAPIClass):
         else:
             self._backend_config = backend_config
 
-        tmp_coupling_comm = commutator(self._bath._coupling_operator)
-        tmp_coupling_acomm = acommutator(self._bath._coupling_operator)
-        self._coupling_comm = tmp_coupling_comm.diagonal()
-        self._coupling_acomm = tmp_coupling_acomm.diagonal()
-
         self._dynamics = None
         self._backend_instance = None
 
@@ -315,8 +310,8 @@ class Tempo(BaseAPIClass):
             dk,
             parameters=self._parameters,
             correlations=self._correlations,
-            coupling_acomm=self._coupling_acomm,
-            coupling_comm=self._coupling_comm,
+            coupling_acomm=self._bath.coupling_acomm,
+            coupling_comm=self._bath.coupling_comm,
             unique=self._unique,
             north_deg_positions=tmp_north_deg_positions,
             west_deg_positions=tmp_west_deg_positions)
@@ -619,17 +614,13 @@ class MeanFieldTempo(BaseAPIClass):
         tmp_west_deg_positions = np.array([np.where( \
             bath.west_degeneracy_map == i)[0][0] for i in \
                 range(np.max(bath.west_degeneracy_map)+1)])
-        tmp_coupling_comm = commutator(bath._coupling_operator)
-        tmp_coupling_acomm = acommutator(bath._coupling_operator)
-        coupling_comm = tmp_coupling_comm.diagonal()
-        coupling_acomm = tmp_coupling_acomm.diagonal()
         def influence(dk: int) -> ndarray:
             return influence_matrix(
                 dk,
                 parameters=self._parameters,
                 correlations=bath.correlations,
-                coupling_acomm=coupling_acomm,
-                coupling_comm=coupling_comm,
+                coupling_acomm=bath.coupling_acomm,
+                coupling_comm=bath.coupling_comm,
                 unique=self._unique,
                 north_deg_positions=tmp_north_deg_positions,
                 west_deg_positions=tmp_west_deg_positions)

--- a/oqupy/tempo.py
+++ b/oqupy/tempo.py
@@ -41,7 +41,6 @@ from oqupy.config import INTEGRATE_EPSREL, SUBDIV_LIMIT
 from oqupy.config import TEMPO_BACKEND_CONFIG
 from oqupy.correlations import BaseCorrelations
 from oqupy.dynamics import Dynamics, MeanFieldDynamics
-from oqupy.operators import commutator, acommutator
 from oqupy.system import BaseSystem, System, TimeDependentSystem,\
     TimeDependentSystemWithField, MeanFieldSystem
 from oqupy.backends.tempo_backend import TempoBackend
@@ -346,13 +345,13 @@ class Tempo(BaseAPIClass):
                 self._parameters.subdiv_limit,
                 self._parameters.liouvillian_epsrel)
         if self._unique:
-            sum_north = np.array([1.0]* \
-                (np.max(self._bath.north_degeneracy_map)+1))
-            sum_west = np.array([1.0]* \
-                (np.max(self._bath.west_degeneracy_map)+1))
+            sum_north = np.ones(np.max(self._bath.north_degeneracy_map)+1,
+                                dtype=float)
+            sum_west = np.ones(np.max(self._bath.west_degeneracy_map)+1,
+                               dtype=float)
         else:
-            sum_north = np.array([1.0]*(dim**2))
-            sum_west = np.array([1.0]*(dim**2))
+            sum_north = np.ones(dim**2, dtype=float)
+            sum_west = np.ones(dim**2, dtype=float)
         dkmax = self._parameters.dkmax
         epsrel = self._parameters.epsrel
         self._backend_instance = TempoBackend(
@@ -560,16 +559,16 @@ class MeanFieldTempo(BaseAPIClass):
         compute_field = self._compute_field
         compute_field_derivative = self._compute_field_derivative
         if self._unique:
-            sum_north_list = [np.array([1.0]* \
-                (np.max(bath.north_degeneracy_map)+1))
+            sum_north_list = [np.ones(np.max(bath.north_degeneracy_map)+1,
+                                      dtype=float)
                 for bath in self._parsed_parameters_dict["bath"]]
-            sum_west_list = [np.array([1.0]* \
-                (np.max(bath.west_degeneracy_map)+1))
+            sum_west_list = [np.ones(np.max(bath.west_degeneracy_map)+1,
+                                      dtype=float)
                 for bath in self._parsed_parameters_dict["bath"]]
         else:
-            sum_north_list = [np.array([1.0]*(dim**2))
+            sum_north_list = [np.ones(dim**2, dtype=float)
                     for dim in self._parsed_parameters_dict["hs_dim"]]
-            sum_west_list = [np.array([1.0]*(dim**2))
+            sum_west_list = [np.ones(dim**2, dtype=float)
                     for dim in self._parsed_parameters_dict["hs_dim"]]
         north_degeneracy_list = [bath.north_degeneracy_map
                 for bath in self._parsed_parameters_dict["bath"]]

--- a/pylintrc
+++ b/pylintrc
@@ -140,6 +140,7 @@ disable=print-statement,
         abstract-method,                  # GEFux: added for development
         consider-using-enumerate,         # GEFux: added by hand
         consider-using-f-string,          # GEFux: added for development
+		too-many-arguments,				  # piperfw: added for development (MF degeneracy)
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/coverage/tempo_parameters_test.py
+++ b/tests/coverage/tempo_parameters_test.py
@@ -54,8 +54,12 @@ def test_tempo_parameters():
 def test_tempo_parameters_bad_input():
     with pytest.raises(TypeError):
         tempo.TempoParameters("x", 1.0e-5, 4.2, None, None, None, 2.0e-6, "rough", "bla")
+    with pytest.raises(ValueError):
+        tempo.TempoParameters(-0.1, 1.0e-05, None, None, None, None, 2.0e-6, "rough", "bla")
     with pytest.raises(TypeError):
         tempo.TempoParameters(0.1, "x", 4.2, None, None, None, 2.0e-6, "rough", "bla")
+    with pytest.raises(ValueError):
+        tempo.TempoParameters(0.1, -1.0e-10, 4.2, None, None, None, 2.0e-6, "rough", "bla")
     with pytest.raises(TypeError):
         tempo.TempoParameters(0.1, 1.0e-05, "x", None, None, None, 2.0e-6, "rough", "bla")
     with pytest.raises(ValueError):
@@ -68,8 +72,14 @@ def test_tempo_parameters_bad_input():
         tempo.TempoParameters(0.1, 1.0e-05, 1.0, 1, None, None, 2.0e-6, "rough", "bla")
     with pytest.raises(TypeError):
         tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, "x", None, 2.0e-6, "rough", "bla")
+    with pytest.raises(ValueError):
+        tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, -99, None, 2.0e-6, "rough", "bla")
     with pytest.raises(TypeError):
         tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, None,  "x", 2.0e-6, "rough", "bla")
+    with pytest.raises(ValueError):
+        tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, None, -1000, 2.0e-6, "rough", "bla")
     with pytest.raises(TypeError):
         tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, None, None, "x", "rough", "bla")
+    with pytest.raises(ValueError):
+        tempo.TempoParameters(0.1, 1.0e-05, 4.2, None, None, None, -2.0e-6, "rough", "bla")
 

--- a/tutorials/mf_tempo.ipynb
+++ b/tutorials/mf_tempo.ipynb
@@ -408,7 +408,8 @@
     "                                 initial_state_list=initial_state_list,\n",
     "                                 initial_field=initial_field,\n",
     "                                 start_time=start_time,\n",
-    "                                 parameters=tempo_parameters)\n",
+    "                                 parameters=tempo_parameters,\n",
+    "                                 unique=True)\n",
     "mean_field_dynamics = tempo_sys.compute(end_time=end_time)"
    ]
   },


### PR DESCRIPTION
Make use of the degeneracy checking introduced by #113 in `MeanFieldTempo` / `MeanFieldTempoBackend`.

This calls `BaseTempoBackend` from `MeanFieldTempoBackend` with the optional `unique=True` and degeneracy map, dimension arguments for each mean-field system.

Coverage and physics tests for mean-field with degeneracy checking (`unique=True`).

Other changes:
- Added `ValueError` checks in `tests/coverage/tempo_parameters_test.py` to improve coverage of `tempo.py` (this is now close to 100%; the missed parts are the use of the optional `backend_config` argument - which would require more extensive parsing if tested)
- `Bath` now has `acomm` and `comm` properties for coupling operator anticommutor/commutator diagonal elements, rather than these having to be re-created in `tempo.py`
- [style] use `np.ones` instead of `[1.0] * num` to create constant arrays
- [style] had to disable `too-many-arguments` in `pylintrc` as number of arguments for `MeanFieldTempoBackend` now exceeds 15 - we should probably look to consolidate this at some point
- added assertions in `BaseTempoBackend` to check degeneracy maps and dim are supplied if `unique=True`. This is not user facing i.e. just to help developers - happy to undo this

