### PR TITLE
PT-TEMPO degeneracy checking

### DIFF
--- a/examples/mean-field-process.py
+++ b/examples/mean-field-process.py
@@ -53,7 +53,8 @@ pt_tempo_parameters = oqupy.TempoParameters(
 process_tensor = oqupy.pt_tempo_compute(bath=bath,
                                         start_time=0.0,
                                         end_time=end_time,
-                                        parameters=pt_tempo_parameters)
+                                        parameters=pt_tempo_parameters,
+                                        unique=True)
 control = None 
 
 mean_field_dynamics = oqupy.compute_dynamics_with_field(

--- a/examples/simple_dynamics.py
+++ b/examples/simple_dynamics.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import sys
+sys.path.insert(0, '.')
+import oqupy
+import numpy as np
+import matplotlib.pyplot as plt
+sigma_x = oqupy.operators.sigma("x")
+sigma_z = oqupy.operators.sigma("z")
+up_density_matrix = oqupy.operators.spin_dm("z+")
+Omega = 1.0
+omega_cutoff = 5.0
+alpha = 0.3
+
+system = oqupy.System(0.5 * Omega * sigma_x)
+correlations = oqupy.PowerLawSD(alpha=alpha,
+                                zeta=1,
+                                cutoff=omega_cutoff,
+                                cutoff_type='exponential')
+bath = oqupy.Bath(0.5 * sigma_z, correlations)
+tempo_parameters = oqupy.TempoParameters(dt=0.1, tcut=3.0, epsrel=10**(-4))
+
+dynamics = oqupy.tempo_compute(system=system,
+                               bath=bath,
+                               initial_state=up_density_matrix,
+                               start_time=0.0,
+                               end_time=2.0,
+                               parameters=tempo_parameters,
+                               unique=True)
+t, s_z = dynamics.expectations(0.5*sigma_z, real=True)
+print(s_z)
+plt.plot(t, s_z, label=r'$\alpha=0.3$')
+plt.xlabel(r'$t\,\Omega$')
+plt.ylabel(r'$\langle\sigma_z\rangle$')
+#plt.savefig('simple_dynamics.png')
+plt.show()


### PR DESCRIPTION
This pull request aims to resolve most of issue #115, by implementing degeneracy checking for PT-TEMPO. Further work needs to be done to verify the failing test, although it does pass with epsrel=0 up to 10 decimal places, a later pull request should confirm the accuracy of the approach before making this default behaviour.

I have left unticked what I think are un relevant checks, otherwise all checks done. Note there is an ignored pylint test for too many instance attributes, as this is related to a general refactor of the PtTempoBackend class that will be resolved during tidy up of classes.

# Pull Request Check List

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [ ] API code contributions include input checks (defensive code).
* [ ] API code contributions include helpful error messages.
* [ ] The documentation has been updated:
  - [x] docstring for all new functions/methods/classes/modules.
  - [x] consistent style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [ ] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
