### PR TITLE
Performance testing of degeneracy checking for PT generation

### DIFF
--- a/tests/performance/analysis/pt_degen_plots.py
+++ b/tests/performance/analysis/pt_degen_plots.py
@@ -15,15 +15,15 @@
 Skript to plot the PT-TEBD performance analysis results.
 """
 
-import sys
-sys.path.insert(0,'.')
-
-import numpy as np
-import matplotlib.pyplot as plt
-import dill
-
-import oqupy
 import oqupy.operators as op
+import oqupy
+from operator import itemgetter
+import dill
+import matplotlib.pyplot as plt
+import numpy as np
+import sys
+sys.path.insert(0, '.')
+
 
 plt.style.use('./tests/performance/analysis/matplotlib_style.mplstyle')
 
@@ -37,3 +37,38 @@ styles = ['-', '--', '-.', ':']
 # PLOT
 # -----------------------------------------------------------------------------
 
+result_list = all_results[0]
+
+unique_wall_times = []
+unique_spin_array = []
+non_unique_wall_times = []
+non_unique_spin_array = []
+
+for results in result_list:
+
+    unique_wall_times.extend(list(map(itemgetter('walltime'),
+                                      filter(itemgetter('unique'),
+                                             results))))
+    unique_spin_array.extend(list(map(itemgetter('spin_size'),
+                                      filter(itemgetter('unique'),
+                                             results))))
+    non_unique_wall_times.extend(list(map(itemgetter('walltime'),
+                                          filter(lambda x: not x.get('unique'),
+                                                 results))))
+    non_unique_spin_array.extend(list(map(itemgetter('spin_size'),
+                                          filter(lambda x: not x.get('unique'),
+                                                 results))))
+
+fig, ax = plt.subplots()
+ax.plot(unique_spin_array, unique_wall_times, label="on")
+ax.plot(non_unique_spin_array, non_unique_wall_times, label="off")
+ax.legend(title="Unique")
+ax.set_yscale('log')
+ax.set_ylabel("Walltime (s)")
+ax.set_xlabel("Spin size")
+fig.savefig("./tests/data/plots/pt-degen-results.pdf")
+
+# -----------------------------------------------------------------------------
+
+
+plt.show()

--- a/tests/performance/analysis/pt_degen_plots.py
+++ b/tests/performance/analysis/pt_degen_plots.py
@@ -1,0 +1,39 @@
+# Copyright 2024 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Skript to plot the PT-TEBD performance analysis results.
+"""
+
+import sys
+sys.path.insert(0,'.')
+
+import numpy as np
+import matplotlib.pyplot as plt
+import dill
+
+import oqupy
+import oqupy.operators as op
+
+plt.style.use('./tests/performance/analysis/matplotlib_style.mplstyle')
+
+with open("./tests/data/performance_results/pt_degen.pkl", 'rb') as f:
+    all_results = dill.load(f)
+
+styles = ['-', '--', '-.', ':']
+
+# -----------------------------------------------------------------------------
+
+# PLOT
+# -----------------------------------------------------------------------------
+

--- a/tests/performance/analysis/pt_degen_plots.py
+++ b/tests/performance/analysis/pt_degen_plots.py
@@ -14,6 +14,8 @@
 """
 Skript to plot the PT-TEBD performance analysis results.
 """
+import sys
+sys.path.insert(0, '.')
 
 import oqupy.operators as op
 import oqupy
@@ -21,8 +23,6 @@ from operator import itemgetter
 import dill
 import matplotlib.pyplot as plt
 import numpy as np
-import sys
-sys.path.insert(0, '.')
 
 
 plt.style.use('./tests/performance/analysis/matplotlib_style.mplstyle')

--- a/tests/performance/analysis/pt_degen_run.py
+++ b/tests/performance/analysis/pt_degen_run.py
@@ -1,0 +1,32 @@
+# Copyright 2024 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Script to run the PT performance analysis.
+"""
+
+import sys
+sys.path.insert(0,'.')
+
+import dill
+
+from tests.performance.run_all import run_all
+from tests.performance.pt_degen import ALL_TESTS
+
+# -- computation --------------------------------------------------------------
+
+all_results = run_all(ALL_TESTS)
+with open('./tests/data/performance_results/pt_degen.pkl', 'wb') as f:
+    dill.dump(all_results, f)
+
+print("... all done.")

--- a/tests/performance/pt_degen.py
+++ b/tests/performance/pt_degen.py
@@ -1,24 +1,68 @@
-#!/usr/bin/env python
+# Copyright 2020 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Performance test for degeneracy checking in process tensor generation
+"""
+import oqupy
+from time import perf_counter
+import numpy as np
+import os
+import sys
+sys.path.insert(0, '.')
+
 
 def pt_degen_performance_A(spin_size, unique):
+    p = {'alpha': 0.1,
+         'zeta': 1.0,
+         'temperature': 0.0,
+         'cutoff': 1.0,
+         'cutoff_type': 'exponential',
+         'dt': 0.2,
+         'epsrel': 1e-6,
+         'tcut': 2.0,
+         'end_t': 2.0}
+
     correlations = oqupy.PowerLawSD(alpha=p['alpha'],
-                                      zeta=p['zeta'],
-                                      cutoff=p['cutoff'],
-                                      cutoff_type=cutoff_type,
-                                      temperature=p['T'])
-    bath = oqupy.Bath(oqupy.operators.sigma("z")/2.0, correlations)
-    pt_tempo_parameters = oqupy.TempoParameters(dt=dt, tcut=p['tcut'], epsrel=epsrel)
-    t0 = time()
-    pt_tempo_compute(unqiue=unique)
-    result['walltime'] = time()-t0
+                                    zeta=p['zeta'],
+                                    cutoff=p['cutoff'],
+                                    cutoff_type=p['cutoff_type'],
+                                    temperature=p['temperature'])
+
+    coupling_op = np.diag(
+        np.arange(spin_size, -spin_size+0.1, -1, dtype=float))
+
+    bath = oqupy.Bath(coupling_operator=coupling_op,
+                      correlations=correlations)
+    pt_tempo_parameters = oqupy.TempoParameters(
+        dt=p['dt'], tcut=p['tcut'], epsrel=p['epsrel'])
+    result = {}
+    t0 = perf_counter()
+    oqupy.pt_tempo_compute(bath=bath,
+                           start_time=0.0,
+                           end_time=p['end_t'],
+                           parameters=pt_tempo_parameters,
+                           unique=unique)
+    result['walltime'] = perf_counter()-t0
     result['unique'] = unique
     result['spin_size'] = spin_size
-    pt.close()
     return result
 
 
-parameters_A1 = [[2, 4, 8], [True, False]]
+parameters_unique = [[0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5],
+                     [True]]
+parameters_non_unique = [[0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5],
+                         [False]]
 
-ALL_TESTS = [ (pt_degen_performance_A, [parameters_A1]),
+ALL_TESTS = [(pt_degen_performance_A, [parameters_unique, parameters_non_unique]),
              ]
-

--- a/tests/performance/pt_degen.py
+++ b/tests/performance/pt_degen.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+def pt_degen_performance_A(spin_size, unique):
+    correlations = oqupy.PowerLawSD(alpha=p['alpha'],
+                                      zeta=p['zeta'],
+                                      cutoff=p['cutoff'],
+                                      cutoff_type=cutoff_type,
+                                      temperature=p['T'])
+    bath = oqupy.Bath(oqupy.operators.sigma("z")/2.0, correlations)
+    pt_tempo_parameters = oqupy.TempoParameters(dt=dt, tcut=p['tcut'], epsrel=epsrel)
+    t0 = time()
+    pt_tempo_compute(unqiue=unique)
+    result['walltime'] = time()-t0
+    result['unique'] = unique
+    result['spin_size'] = spin_size
+    pt.close()
+    return result
+
+
+parameters_A1 = [[2, 4, 8], [True, False]]
+
+ALL_TESTS = [ (pt_degen_performance_A, [parameters_A1]),
+             ]
+

--- a/tests/performance/pt_degen.py
+++ b/tests/performance/pt_degen.py
@@ -14,12 +14,13 @@
 """
 Performance test for degeneracy checking in process tensor generation
 """
-import oqupy
-from time import perf_counter
-import numpy as np
-import os
 import sys
-sys.path.insert(0, '.')
+from time import perf_counter
+sys.path.insert(0,'.')
+
+import numpy as np
+
+import oqupy
 
 
 def pt_degen_performance_A(spin_size, unique):
@@ -66,3 +67,5 @@ parameters_non_unique = [[0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5],
 
 ALL_TESTS = [(pt_degen_performance_A, [parameters_unique, parameters_non_unique]),
              ]
+
+REQUIRED_PTS = []


### PR DESCRIPTION
This pull request adds a performance benchmark for comparing generating process tensors with and without degeneracy checking, using a S_z coupling operator of varying spin size.

# Pull Request Check List

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [x] API code contributions include input checks (defensive code).
* [x] API code contributions include helpful error messages.
* [x] The documentation has been updated:
  - [x] docstring for all new functions/methods/classes/modules.
  - [x] consistent style of all docstrings.
  - [x] for new modules: `/docs/pages/modules.rst` has been updated.
  - [x] for api contributions: `/docs/pages/api.rst` has been updated.
  - [x] for api contributions: tutorials and examples have been updated.
