### PR TITLE
Fix #157: PtTebd.get_augmented_mps()

### DIFF
--- a/oqupy/mps_mpo.py
+++ b/oqupy/mps_mpo.py
@@ -394,7 +394,7 @@ class AugmentedMPS(BaseAPIClass):
             shape = deepcopy(tmp_gamma.shape)
             rank = len(shape)
             if rank == 4:
-                tmp_gamma = np.swapaxes(tmp_gamma,2,3)
+                pass
             elif rank == 3:
                 tmp_gamma.shape = (shape[0], shape[1], 1, shape[2])
             elif rank == 2:

--- a/tests/coverage/pt_tebd_test.py
+++ b/tests/coverage/pt_tebd_test.py
@@ -18,12 +18,14 @@ import pytest
 import numpy as np
 import oqupy
 
-up_dm = oqupy.operators.spin_dm("z+")
-system_chain = oqupy.SystemChain(hilbert_space_dimensions=[2,3])
-initial_augmented_mps = oqupy.AugmentedMPS([up_dm, np.diag([1,0,0])])
-pt_tebd_params = oqupy.PtTebdParameters(dt=0.2, order=2, epsrel=1.0e-4)
 
-def test_get_augmented_mps():
+
+def test_get_augmented_mps_A():
+    up_dm = oqupy.operators.spin_dm("z+")
+    system_chain = oqupy.SystemChain(hilbert_space_dimensions=[2,3])
+    initial_augmented_mps = oqupy.AugmentedMPS([up_dm, np.diag([1,0,0])])
+    pt_tebd_params = oqupy.PtTebdParameters(dt=0.2, order=2, epsrel=1.0e-4)
+
     pt_tebd = oqupy.PtTebd(
         initial_augmented_mps=initial_augmented_mps,
         system_chain=system_chain,
@@ -38,3 +40,73 @@ def test_get_augmented_mps():
     augmented_mps = pt_tebd.get_augmented_mps()
     assert augmented_mps.gammas[0].shape == (1,4,1,1)
     assert augmented_mps.gammas[1].shape == (1,9,1,1)
+
+
+def test_get_augmented_mps_B():
+
+    dt = 0.2
+    epsrel = 1.0e-4
+    num_steps = 4
+
+
+    sx = 0.5 * oqupy.operators.sigma("x")
+    sy = 0.5 * oqupy.operators.sigma("y")
+    sz = 0.5 * oqupy.operators.sigma("z")
+    up_dm = oqupy.operators.spin_dm("z+")
+    down_dm = oqupy.operators.spin_dm("z-")
+    mixed_dm = oqupy.operators.spin_dm("mixed")
+
+    #System
+    N = 3 # >=3
+    epsilon = 1
+    J_gamma = [1.3, 0.7, 1.2]
+    system_chain = oqupy.SystemChain([2]*N)
+
+    for n in range(N):
+        system_chain.add_site_hamiltonian(site = n, hamiltonian= epsilon*sz)
+
+    for n in range(N-1):
+        for J, S in zip (J_gamma ,[sx,sy,sz]):
+            system_chain.add_nn_hamiltonian(site = n, 
+                                            hamiltonian_l = J*S,
+                                            hamiltonian_r = S)
+
+    #parameters
+    pt_tebd_params = oqupy.PtTebdParameters(dt = dt,
+                                        order = 2,
+                                        epsrel = epsrel)
+
+    dynamics_sites = list(range(0, N))
+    initial_augmented_mps = oqupy.AugmentedMPS([up_dm]*N) 
+
+
+    correlations = oqupy.PowerLawSD(alpha=0.05,
+                                    zeta=1,
+                                    cutoff=1.0,
+                                    cutoff_type='exponential',
+                                    temperature=0.0)
+    bath = oqupy.Bath(0.5 * sy, correlations)
+    pt_tempo_parameters = oqupy.TempoParameters(dt=dt,
+                                                epsrel=1.0e-4,
+                                                dkmax=10)
+
+    pt = oqupy.pt_tempo_compute(bath=bath,
+                                start_time=0.0,
+                                end_time=num_steps * dt,
+                                parameters=pt_tempo_parameters,
+                                progress_type='bar')
+
+
+    pt_tebd = oqupy.PtTebd(initial_augmented_mps = initial_augmented_mps,
+                            system_chain = system_chain,
+                            process_tensors = [None]+[pt]+[None]*(N-2),
+                            parameters = pt_tebd_params,
+                            dynamics_sites = dynamics_sites,
+                            chain_control=None
+                            )
+
+    end_step = 2
+    pt_tebd.compute(end_step = 2, progress_type = 'bar')
+
+    new_augmented_mps = pt_tebd.get_augmented_mps()
+    assert new_augmented_mps.gammas[1].shape[2] == pt.get_bond_dimensions()[end_step]


### PR DESCRIPTION
# Pull Request Check List

Fixes #157: Ironious axis swap when exporting the augmented mps.

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/OQuPy/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
* [x] Added test for changed/added code.
