### PR TITLE
Use eigh in bath op assertion

### DIFF
--- a/oqupy/bath.py
+++ b/oqupy/bath.py
@@ -71,7 +71,7 @@ class Bath(BaseAPIClass):
             self._coupling_operator = tmp_coupling_operator
             self._unitary = np.identity(self._dimension)
         else:
-            w, v = np.linalg.eig(tmp_coupling_operator)
+            w, v = np.linalg.eigh(tmp_coupling_operator)
             self._coupling_operator = np.diag(w)
             self._unitary = v
             assert np.allclose(tmp_coupling_operator, \


### PR DESCRIPTION
#165 

The constructor already asserts the coupling operator is Hermitian, so using `eigh` should be safe and not fail in the way described in the issue.

Never done a one-character Pull Request before. Ran the tests just to be sure!